### PR TITLE
Improve build system flexibility and update README

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 TabWidth: 2
 IndentWidth: 2
-UseTab: Always
+UseTab: Never
 IndentPPDirectives: BeforeHash
 SortIncludes: true
 AlignAfterOpenBracket: true

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -21,13 +21,11 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
 **Additional context**

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: Build and Run
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "libfetch-rewrite" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ uwufetch_*
 *.so
 *.a
 *.dSYM
+.nvim-session

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ all: $(NAME) libs
 libs: libfetch.a libfetch.so
 
 $(NAME): $(BIN_FILES) libfetch.a
-	$(CC) $(ALL_CFLAGS) -o $@ $^
+	$(CC) $(ALL_CFLAGS) $(LDFLAGS) -o $@ $^
 fetch.o: $(LIB_FILES)
 	$(CC) -fPIC -c $(ALL_CFLAGS) -o $@ $^
 libfetch.so: fetch.o
-	$(CC) $(ALL_CFLAGS) -shared -o $@ $^
+	$(CC) $(ALL_CFLAGS) -shared -Wl,-soname,$@.$(UWUFETCH_VERSION) $(LDFLAGS) -o $@ $^
 libfetch.a: fetch.o
 	$(AR) rcs $@ $^
 
@@ -104,7 +104,7 @@ installdirs:
 
 install: $(NAME) libfetch.so installdirs man
 	$(INSTALL_PROGRAM) $(NAME) $(DESTDIR)$(bindir)
-	$(INSTALL_PROGRAM) libfetch.so $(DESTDIR)$(libdir)
+	$(INSTALL_PROGRAM) libfetch.so $(DESTDIR)$(libdir)/libfetch.so.$(UWUFETCH_VERSION)
 	$(INSTALL_DATA) res/*.png $(DESTDIR)$(libdir)/$(NAME)
 	$(INSTALL_DATA) res/ascii/* $(DESTDIR)$(libdir)/$(NAME)/ascii
 	$(INSTALL_DATA) $(LIB_FILES:.c=.h) $(DESTDIR)$(includedir)
@@ -114,7 +114,7 @@ install: $(NAME) libfetch.so installdirs man
 uninstall:
 	$(RM) $(DESTDIR)$(bindir)/$(NAME)
 	$(RM) -r $(DESTDIR)$(libdir)/$(NAME)
-	$(RM) $(DESTDIR)$(libdir)/libfetch.so
+	$(RM) $(DESTDIR)$(libdir)/libfetch.so.$(UWUFETCH_VERSION)
 	$(RM) $(DESTDIR)$(includedir)/$(LIB_FILES:.c=.h)
 	$(RM) -r $(DESTDIR)$(sysconfdir)/$(NAME)
 	$(RM) $(DESTDIR)$(man1dir)/$(NAME)$(manext).gz

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ release: all man
 	cp $(RELEASE_SCRIPTS) $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
 	cp -r res $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
 	cp $(NAME)$(EXT) $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
-	cp $(NAME)$(manext).gz $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
+	cp $(NAME)$(manext) $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
 	cp lib$(LIB_FILES:.c=.so) $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
 	cp $(LIB_FILES:.c=.h) $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
 	cp default.config $(NAME)_$(UWUFETCH_VERSION)-$(PLATFORM_ABBR)
@@ -109,7 +109,7 @@ install: $(NAME) libfetch.so installdirs man
 	$(INSTALL_DATA) res/ascii/* $(DESTDIR)$(libdir)/$(NAME)/ascii
 	$(INSTALL_DATA) $(LIB_FILES:.c=.h) $(DESTDIR)$(includedir)
 	$(INSTALL_DATA) default.config $(DESTDIR)$(sysconfdir)/$(NAME)/config
-	$(INSTALL_DATA) $(NAME)$(manext).gz $(DESTDIR)$(man1dir)
+	$(INSTALL_DATA) $(NAME)$(manext) $(DESTDIR)$(man1dir)
 
 uninstall:
 	$(RM) $(DESTDIR)$(bindir)/$(NAME)
@@ -117,7 +117,7 @@ uninstall:
 	$(RM) $(DESTDIR)$(libdir)/libfetch.so.$(UWUFETCH_VERSION)
 	$(RM) $(DESTDIR)$(includedir)/$(LIB_FILES:.c=.h)
 	$(RM) -r $(DESTDIR)$(sysconfdir)/$(NAME)
-	$(RM) $(DESTDIR)$(man1dir)/$(NAME)$(manext).gz
+	$(RM) $(DESTDIR)$(man1dir)/$(NAME)$(manext)
 
 clean:
 	$(RM) -r $(NAME) $(NAME)_* *.o *.so *.a *.exe
@@ -127,7 +127,8 @@ ascii_debug:
 	ls res/ascii/$(ASCII).txt | entr -c ./$(NAME) -d $(ASCII)
 
 man:
-	sed "s/{DATE}/$(shell date '+%d %B %Y')/g" $(NAME).1 | sed "s/{UWUFETCH_VERSION}/$(UWUFETCH_VERSION)/g" | gzip > $(NAME)$(manext).gz
+	sed -i -e "s/{DATE}/$(shell date '+%d %B %Y')/g" \
+		-e "s/{UWUFETCH_VERSION}/$(UWUFETCH_VERSION)/g" $(NAME)$(manext)
 
 man_debug:
 	@clear

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## NOTE: libfetch-rewrite
+I am currently rewriting the "fetching system", so issues related to the main branch will not be fixed until the rewrite session is completed (when [libfetch-rewrite](https://github.com/TheDarkBug/uwufetch/tree/libfetch-rewrite) will be merged with main).
+
+
 # UwUFetch
 
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Build requisites:
 - Make
 - A C compiler
   - A iOS patched SDK (if you build UwUfetch under iOS device)
+- git
 
 To install UwUfetch from the source, type these commands in the terminal:
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To install UwUfetch from the source, type these commands in the terminal:
 ```shell
 git clone https://github.com/TheDarkBug/uwufetch.git
 cd uwufetch
-make build # add "CFLAGS+=-D__IPHONE__" if you are building for iOS
+make # add "CFLAGS=-D__IPHONE__" if you are building for iOS
 sudo make install
 ```
 
@@ -81,11 +81,11 @@ sudo make uninstall
 #### Available Make targets
 
 ```shell
-make build              # builds uwufetch and libfetch
-make lib                # builds only libfetch
-make debug              # use for debug
-make install            # installs uwufetch (needs root permissons)
-make uninstall          # uninstalls uwufetch (needs root permissons)
+make all                # builds uwufetch and libfetch (shared and static)
+make libs               # builds only libfetch (shared and static)
+make ARGS="..." debug   # run "./uwufetch $(ARGS)" in debugging mode
+make install            # installs uwufetch
+make uninstall          # uninstalls uwufetch
 make clean              # removes all build output
 make man                # compiles man page
 make man_debug          # compiles man page and shows 'man' output

--- a/fetch.c
+++ b/fetch.c
@@ -14,7 +14,7 @@
  */
 
 #ifdef __APPLE__
-	#include <TargetConditionals.h> // for checking iOS
+  #include <TargetConditionals.h> // for checking iOS
 #endif
 #include <dirent.h>
 #include <stdio.h>
@@ -22,31 +22,31 @@
 #include <string.h>
 #include <unistd.h>
 #if defined(__APPLE__) || defined(__BSD__)
-	#include <sys/sysctl.h>
-	#if defined(__OPENBSD__)
-		#include <sys/time.h>
-	#else
-		#include <time.h>
-	#endif // defined(__OPENBSD__)
-#else		 // defined(__APPLE__) || defined(__BSD__)
-	#ifdef __BSD__
-	#else // defined(__BSD__) || defined(_WIN32)
-		#ifndef _WIN32
-			#ifndef __OPENBSD__
-				#include <sys/sysinfo.h>
-			#else	 // __OPENBSD__
-			#endif // __OPENBSD__
-		#else		 // _WIN32
-			#include <sysinfoapi.h>
-		#endif // _WIN32
-	#endif	 // defined(__BSD__) || defined(_WIN32)
-#endif		 // defined(__APPLE__) || defined(__BSD__)
+  #include <sys/sysctl.h>
+  #if defined(__OPENBSD__)
+    #include <sys/time.h>
+  #else
+    #include <time.h>
+  #endif // defined(__OPENBSD__)
+#else    // defined(__APPLE__) || defined(__BSD__)
+  #ifdef __BSD__
+  #else // defined(__BSD__) || defined(_WIN32)
+    #ifndef _WIN32
+      #ifndef __OPENBSD__
+        #include <sys/sysinfo.h>
+      #else  // __OPENBSD__
+      #endif // __OPENBSD__
+    #else    // _WIN32
+      #include <sysinfoapi.h>
+    #endif // _WIN32
+  #endif   // defined(__BSD__) || defined(_WIN32)
+#endif     // defined(__APPLE__) || defined(__BSD__)
 #ifndef _WIN32
-	#include <sys/ioctl.h>
-	#include <sys/utsname.h>
-	#include <pthread.h> // linux only right now
-#else									 // _WIN32
-	#include <windows.h>
+  #include <pthread.h> // linux only right now
+  #include <sys/ioctl.h>
+  #include <sys/utsname.h>
+#else // _WIN32
+  #include <windows.h>
 CONSOLE_SCREEN_BUFFER_INFO csbi;
 #endif // _WIN32
 
@@ -59,22 +59,22 @@ bool* get_verbose_handle() { return &verbose_enabled; }
 #endif
 
 #ifndef PKGPATH
-	#ifdef __APPLE__
-		#define PKGPATH "/usr/local/bin/"
-	#else
-		#define PKGPATH "/usr/bin/"
-	#endif
+  #ifdef __APPLE__
+    #define PKGPATH "/usr/local/bin/"
+  #else
+    #define PKGPATH "/usr/bin/"
+  #endif
 #endif
 
 #ifdef __APPLE__
 // buffers where data fetched from sysctl are stored
-	#define CPUBUFFERLEN 128
+  #define CPUBUFFERLEN 128
 
 char cpu_buffer[CPUBUFFERLEN];
 size_t cpu_buffer_len = CPUBUFFERLEN;
 
 // Installed RAM
-int64_t mem_buffer		= 0;
+int64_t mem_buffer    = 0;
 size_t mem_buffer_len = sizeof(mem_buffer);
 
 // uptime
@@ -83,694 +83,694 @@ size_t time_buffer_len = sizeof(time_buffer);
 #endif // __APPLE__
 
 struct package_manager {
-	char* command_path;
-	char* command_string; // command to get number of packages installed
-	char* pkgman_name;		// name of the package manager
+  char* command_path;
+  char* command_string; // command to get number of packages installed
+  char* pkgman_name;    // name of the package manager
 };
 
 // truncates the given string
 void truncate_str(char* string, int target_width) {
-	char arr[target_width];
-	for (int i = 0; i < target_width; i++) arr[i] = string[i];
-	string = arr;
+  char arr[target_width];
+  for (int i = 0; i < target_width; i++) arr[i] = string[i];
+  string = arr;
 }
 
 // remove square brackets (for gpu names)
 void remove_brackets(char* str) {
-	int i = 0, j = 0;
-	while (i < (int)strlen(str))
-		if (str[i] == '[' || str[i] == ']')
-			for (j = i; j < (int)strlen(str); j++) str[j] = str[j + 1];
-		else
-			i++;
+  int i = 0, j = 0;
+  while (i < (int)strlen(str))
+    if (str[i] == '[' || str[i] == ']')
+      for (j = i; j < (int)strlen(str); j++) str[j] = str[j + 1];
+    else
+      i++;
 }
 
 void get_twidth(struct info* user_info) {
-	LOG_I("getting terminal width");
-	// get terminal width used to truncate long names
+  LOG_I("getting terminal width");
+  // get terminal width used to truncate long names
 #ifndef _WIN32
-	ioctl(STDOUT_FILENO, TIOCGWINSZ, &user_info->win);
-	user_info->target_width = user_info->win.ws_col - 30;
-	LOG_V(user_info->target_width);
-#else	 // _WIN32
-	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-	user_info->ws_col	 = csbi.srWindow.Right - csbi.srWindow.Left - 29;
-	user_info->ws_rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
-	LOG_V(user_info->ws_col);
-	LOG_V(user_info->ws_rows);
+  ioctl(STDOUT_FILENO, TIOCGWINSZ, &user_info->win);
+  user_info->target_width = user_info->win.ws_col - 30;
+  LOG_V(user_info->target_width);
+#else  // _WIN32
+  GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+  user_info->ws_col  = csbi.srWindow.Right - csbi.srWindow.Left - 29;
+  user_info->ws_rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+  LOG_V(user_info->ws_col);
+  LOG_V(user_info->ws_rows);
 #endif // _WIN32
 }
 
 void get_sys(struct info* user_info) {
-	LOG_I("getting sys_var struct");
+  LOG_I("getting sys_var struct");
 #ifndef _WIN32
-	uname(&user_info->sys_var);
+  uname(&user_info->sys_var);
 #endif // _WIN32
 #ifndef __APPLE__
-	#ifndef __BSD__
-		#ifndef _WIN32
-	sysinfo(&user_info->sys);
-		#else
-	GetSystemInfo(&user_info->sys);
-		#endif
-	#endif
+  #ifndef __BSD__
+    #ifndef _WIN32
+  sysinfo(&user_info->sys);
+    #else
+  GetSystemInfo(&user_info->sys);
+    #endif
+  #endif
 #endif
 }
 
 // tries to get cpu name
 void* get_cpu(void* argp) {
-	if (!((struct thread_varg*)argp)->thread_flags[0]) return 0;
-	char* buffer					 = ((struct thread_varg*)argp)->buffer;
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
-	FILE* cpuinfo					 = ((struct thread_varg*)argp)->cpuinfo;
-	LOG_I("getting cpu name");
-	if (cpuinfo) {
-		while (fgets(buffer, BUFFER_SIZE, cpuinfo)) {
+  if (!((struct thread_varg*)argp)->thread_flags[0]) return 0;
+  char* buffer           = ((struct thread_varg*)argp)->buffer;
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  FILE* cpuinfo          = ((struct thread_varg*)argp)->cpuinfo;
+  LOG_I("getting cpu name");
+  if (cpuinfo) {
+    while (fgets(buffer, BUFFER_SIZE, cpuinfo)) {
 #ifdef __BSD__
-			if (sscanf(buffer, "hw.model"
-	#ifdef __FREEBSD__
-												 ": "
-	#elif defined(__OPENBSD__)
-												 "="
-	#endif
-												 "%[^\n]",
-								 user_info->cpu_model))
-				break;
+      if (sscanf(buffer, "hw.model"
+  #ifdef __FREEBSD__
+                         ": "
+  #elif defined(__OPENBSD__)
+                         "="
+  #endif
+                         "%[^\n]",
+                 user_info->cpu_model))
+        break;
 #else
-			if (sscanf(buffer, "model name    : %[^\n]", user_info->cpu_model)) break;
+      if (sscanf(buffer, "model name    : %[^\n]", user_info->cpu_model)) break;
 #endif // __BSD__
-		}
-	}
-	if (strlen(user_info->cpu_model) == 0) {
-		LOG_E("failed to get cpu name");
-		rewind(cpuinfo);
-		char cores[4] = "";
-		while (fgets(buffer, BUFFER_SIZE, cpuinfo)) // get the last core number
-			sscanf(buffer, "processor%*[    |	]: %[^\n]", cores);
-		cores[strlen(cores) - 1] += 1; // should be a number
-		sprintf(user_info->cpu_model, "%s Cores", cores);
-	}
-	LOG_V(user_info->cpu_model);
-	return 0;
+    }
+  }
+  if (strlen(user_info->cpu_model) == 0) {
+    LOG_E("failed to get cpu name");
+    rewind(cpuinfo);
+    char cores[4] = "";
+    while (fgets(buffer, BUFFER_SIZE, cpuinfo)) // get the last core number
+      sscanf(buffer, "processor%*[    |	]: %[^\n]", cores);
+    cores[strlen(cores) - 1] += 1; // should be a number
+    sprintf(user_info->cpu_model, "%s Cores", cores);
+  }
+  LOG_V(user_info->cpu_model);
+  return 0;
 }
 
 // tries to get memory usage
 void* get_ram(void* argp) {
-	if (!((struct thread_varg*)argp)->thread_flags[1]) return 0;
-	LOG_I("getting ram");
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  if (!((struct thread_varg*)argp)->thread_flags[1]) return 0;
+  LOG_I("getting ram");
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
 #ifndef __APPLE__
-	#ifdef _WIN32
-	FILE* mem_used_fp			 = popen("wmic os get freevirtualmemory", "r");			 // free memory
-	FILE* mem_total_fp		 = popen("wmic os get totalvirtualmemorysize", "r"); // total memory
-	char mem_used_ch[2137] = {0}, mem_total_ch[2137] = {0};
+  #ifdef _WIN32
+  FILE* mem_used_fp      = popen("wmic os get freevirtualmemory", "r");      // free memory
+  FILE* mem_total_fp     = popen("wmic os get totalvirtualmemorysize", "r"); // total memory
+  char mem_used_ch[2137] = {0}, mem_total_ch[2137] = {0};
 
-	while (fgets(mem_total_ch, sizeof(mem_total_ch), mem_total_fp) != NULL) {
-		if (strstr(mem_total_ch, "TotalVirtualMemorySize") != 0)
-			continue;
-		else if (strstr(mem_total_ch, "  ") == 0)
-			continue;
-		else
-			user_info->ram_total = atoi(mem_total_ch) / 1024;
-	}
-	LOG_V(user_info->ram_total);
-	while (fgets(mem_used_ch, sizeof(mem_used_ch), mem_used_fp) != NULL) {
-		if (strstr(mem_used_ch, "FreeVirtualMemory") != 0)
-			continue;
-		else if (strstr(mem_used_ch, "  ") == 0)
-			continue;
-		else
-			user_info->ram_used = user_info->ram_total - (atoi(mem_used_ch) / 1024);
-	}
-	LOG_V(user_info->ram_used);
-	pclose(mem_used_fp);
-	pclose(mem_total_fp);
-	#else // if not _WIN32
-	char* buffer = ((struct thread_varg*)argp)->buffer;
-	FILE* meminfo;
+  while (fgets(mem_total_ch, sizeof(mem_total_ch), mem_total_fp) != NULL) {
+    if (strstr(mem_total_ch, "TotalVirtualMemorySize") != 0)
+      continue;
+    else if (strstr(mem_total_ch, "  ") == 0)
+      continue;
+    else
+      user_info->ram_total = atoi(mem_total_ch) / 1024;
+  }
+  LOG_V(user_info->ram_total);
+  while (fgets(mem_used_ch, sizeof(mem_used_ch), mem_used_fp) != NULL) {
+    if (strstr(mem_used_ch, "FreeVirtualMemory") != 0)
+      continue;
+    else if (strstr(mem_used_ch, "  ") == 0)
+      continue;
+    else
+      user_info->ram_used = user_info->ram_total - (atoi(mem_used_ch) / 1024);
+  }
+  LOG_V(user_info->ram_used);
+  pclose(mem_used_fp);
+  pclose(mem_total_fp);
+  #else // if not _WIN32
+  char* buffer = ((struct thread_varg*)argp)->buffer;
+  FILE* meminfo;
 
-		#ifdef __BSD__
-			#ifndef __OPENBSD__
-	meminfo = popen("LANG=EN_us freecolor -om 2> /dev/null", "r"); // free alternative for freebsd
-			#else
-	meminfo = popen("LANG=EN_us vmstat 2> /dev/null | grep -v 'procs' | grep -v 'r' | awk '{print $3 "
-									"\" / \" $4}'",
-									"r"); // free alternative for openbsd
-			#endif
-		#else
-	// getting memory info from /proc/meminfo: https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
-	meminfo = fopen("/proc/meminfo",
-									"r"); // popen("LANG=EN_us free -m 2> /dev/null", "r"); // get ram info with free
-		#endif
-	// brackets are here to restrict the access to this int variables, which are temporary
-	{
-		#ifndef __OPENBSD__
-		int memtotal = 0, shmem = 0, memfree = 0, buffers = 0, cached = 0, sreclaimable = 0;
-		#endif
-		while (fgets(buffer, BUFFER_SIZE, meminfo)) {
-		#ifndef __OPENBSD__
-			sscanf(buffer, "MemTotal:       %d", &memtotal);
-			sscanf(buffer, "Shmem:             %d", &shmem);
-			sscanf(buffer, "MemFree:        %d", &memfree);
-			sscanf(buffer, "Buffers:          %d", &buffers);
-			sscanf(buffer, "Cached:          %d", &cached);
-			sscanf(buffer, "SReclaimable:     %d", &sreclaimable);
-		#else
-			sscanf(buffer, "%dM / %dM", &user_info->ram_used, &user_info->ram_total);
-		#endif
-		}
-		#ifndef __OPENBSD__
-		user_info->ram_total = memtotal / 1024;
-		user_info->ram_used = ((memtotal + shmem) - (memfree + buffers + cached + sreclaimable)) / 1024;
-		#endif
-		LOG_V(user_info->ram_total);
-		LOG_V(user_info->ram_used);
-	}
+    #ifdef __BSD__
+      #ifndef __OPENBSD__
+  meminfo = popen("LANG=EN_us freecolor -om 2> /dev/null", "r"); // free alternative for freebsd
+      #else
+  meminfo = popen("LANG=EN_us vmstat 2> /dev/null | grep -v 'procs' | grep -v 'r' | awk '{print $3 "
+                  "\" / \" $4}'",
+                  "r"); // free alternative for openbsd
+      #endif
+    #else
+  // getting memory info from /proc/meminfo: https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
+  meminfo = fopen("/proc/meminfo",
+                  "r"); // popen("LANG=EN_us free -m 2> /dev/null", "r"); // get ram info with free
+    #endif
+  // brackets are here to restrict the access to this int variables, which are temporary
+  {
+    #ifndef __OPENBSD__
+    int memtotal = 0, shmem = 0, memfree = 0, buffers = 0, cached = 0, sreclaimable = 0;
+    #endif
+    while (fgets(buffer, BUFFER_SIZE, meminfo)) {
+    #ifndef __OPENBSD__
+      sscanf(buffer, "MemTotal:       %d", &memtotal);
+      sscanf(buffer, "Shmem:             %d", &shmem);
+      sscanf(buffer, "MemFree:        %d", &memfree);
+      sscanf(buffer, "Buffers:          %d", &buffers);
+      sscanf(buffer, "Cached:          %d", &cached);
+      sscanf(buffer, "SReclaimable:     %d", &sreclaimable);
+    #else
+      sscanf(buffer, "%dM / %dM", &user_info->ram_used, &user_info->ram_total);
+    #endif
+    }
+    #ifndef __OPENBSD__
+    user_info->ram_total = memtotal / 1024;
+    user_info->ram_used = ((memtotal + shmem) - (memfree + buffers + cached + sreclaimable)) / 1024;
+    #endif
+    LOG_V(user_info->ram_total);
+    LOG_V(user_info->ram_used);
+  }
 
-	fclose(meminfo);
-	#endif
+  fclose(meminfo);
+  #endif
 #else // if __APPLE__
-	// Used
-	FILE *mem_wired_fp, *mem_active_fp, *mem_compressed_fp;
-	mem_wired_fp			= popen("vm_stat | awk '/wired/ { printf $4 }' | cut -d '.' -f 1", "r");
-	mem_active_fp			= popen("vm_stat | awk '/active/ { printf $3 }' | cut -d '.' -f 1", "r");
-	mem_compressed_fp = popen("vm_stat | awk '/occupied/ { printf $5 }' | cut -d '.' -f 1", "r");
-	char mem_wired_ch[2137], mem_active_ch[2137], mem_compressed_ch[2137];
-	while (fgets(mem_wired_ch, sizeof(mem_wired_ch), mem_wired_fp) != NULL)
-		while (fgets(mem_active_ch, sizeof(mem_active_ch), mem_active_fp) != NULL)
-			while (fgets(mem_compressed_ch, sizeof(mem_compressed_ch), mem_compressed_fp) != NULL)
-				;
+  // Used
+  FILE *mem_wired_fp, *mem_active_fp, *mem_compressed_fp;
+  mem_wired_fp      = popen("vm_stat | awk '/wired/ { printf $4 }' | cut -d '.' -f 1", "r");
+  mem_active_fp     = popen("vm_stat | awk '/active/ { printf $3 }' | cut -d '.' -f 1", "r");
+  mem_compressed_fp = popen("vm_stat | awk '/occupied/ { printf $5 }' | cut -d '.' -f 1", "r");
+  char mem_wired_ch[2137], mem_active_ch[2137], mem_compressed_ch[2137];
+  while (fgets(mem_wired_ch, sizeof(mem_wired_ch), mem_wired_fp) != NULL)
+    while (fgets(mem_active_ch, sizeof(mem_active_ch), mem_active_fp) != NULL)
+      while (fgets(mem_compressed_ch, sizeof(mem_compressed_ch), mem_compressed_fp) != NULL)
+        ;
 
-	pclose(mem_wired_fp);
-	pclose(mem_active_fp);
-	pclose(mem_compressed_fp);
+  pclose(mem_wired_fp);
+  pclose(mem_active_fp);
+  pclose(mem_compressed_fp);
 
-	int mem_wired			 = atoi(mem_wired_ch);
-	int mem_active		 = atoi(mem_active_ch);
-	int mem_compressed = atoi(mem_compressed_ch);
+  int mem_wired      = atoi(mem_wired_ch);
+  int mem_active     = atoi(mem_active_ch);
+  int mem_compressed = atoi(mem_compressed_ch);
 
-	// Total
-	sysctlbyname("hw.memsize", &mem_buffer, &mem_buffer_len, NULL, 0);
-	user_info->ram_used	 = ((mem_wired + mem_active + mem_compressed) * 4 / 1024);
-	user_info->ram_total = mem_buffer / 1024 / 1024;
-	LOG_V(user_info->ram_total);
-	LOG_V(user_info->ram_used);
+  // Total
+  sysctlbyname("hw.memsize", &mem_buffer, &mem_buffer_len, NULL, 0);
+  user_info->ram_used  = ((mem_wired + mem_active + mem_compressed) * 4 / 1024);
+  user_info->ram_total = mem_buffer / 1024 / 1024;
+  LOG_V(user_info->ram_total);
+  LOG_V(user_info->ram_used);
 #endif
-	return 0;
+  return 0;
 }
 
 // tries to get installed gpu(s)
 void* get_gpu(void* argp) {
-	if (!((struct thread_varg*)argp)->thread_flags[2]) return 0;
-	LOG_I("getting gpu(s)");
-	char* buffer					 = ((struct thread_varg*)argp)->buffer;
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
-	int gpuc							 = 0; // gpu counter
+  if (!((struct thread_varg*)argp)->thread_flags[2]) return 0;
+  LOG_I("getting gpu(s)");
+  char* buffer           = ((struct thread_varg*)argp)->buffer;
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  int gpuc               = 0; // gpu counter
 #ifndef _WIN32
-	setenv("LANG", "en_US", 1); // force language to english
+  setenv("LANG", "en_US", 1); // force language to english
 #endif
-	FILE* gpu;
+  FILE* gpu;
 #ifndef _WIN32
-	LOG_I("getting gpus with lshw");
-	gpu = popen("lshw -class display 2> /dev/null", "r");
+  LOG_I("getting gpus with lshw");
+  gpu = popen("lshw -class display 2> /dev/null", "r");
 
-	// add all gpus to the array gpu_model
-	while (fgets(buffer, BUFFER_SIZE, gpu))
-		if (sscanf(buffer, "    product: %[^\n]", user_info->gpu_model[gpuc])) gpuc++;
+  // add all gpus to the array gpu_model
+  while (fgets(buffer, BUFFER_SIZE, gpu))
+    if (sscanf(buffer, "    product: %[^\n]", user_info->gpu_model[gpuc])) gpuc++;
 #endif
 
-	if (strlen(user_info->gpu_model[0]) < 2) {
-		// get gpus with lspci command
-		if (strcmp(user_info->os_name, "android") != 0) {
+  if (strlen(user_info->gpu_model[0]) < 2) {
+    // get gpus with lspci command
+    if (strcmp(user_info->os_name, "android") != 0) {
 #ifndef __APPLE__
-	#ifdef _WIN32
-			gpu = popen("wmic PATH Win32_VideoController GET Name", "r");
-	#else
-			gpu = popen("lspci -mm 2> /dev/null | grep \"VGA\" | awk -F '\"' '{print $4 $5 $6}'", "r");
-	#endif
+  #ifdef _WIN32
+      gpu = popen("wmic PATH Win32_VideoController GET Name", "r");
+  #else
+      gpu = popen("lspci -mm 2> /dev/null | grep \"VGA\" | awk -F '\"' '{print $4 $5 $6}'", "r");
+  #endif
 #else
-			gpu = popen(
-					"system_profiler SPDisplaysDataType | awk -F ': ' '/Chipset Model: /{ print $2 }'", "r");
+      gpu = popen(
+          "system_profiler SPDisplaysDataType | awk -F ': ' '/Chipset Model: /{ print $2 }'", "r");
 #endif
-		} else
-			gpu = popen("getprop ro.hardware.vulkan 2> /dev/null", "r"); // for android
-	}
+    } else
+      gpu = popen("getprop ro.hardware.vulkan 2> /dev/null", "r"); // for android
+  }
 
-	// get all the gpus
-	while (fgets(buffer, BUFFER_SIZE, gpu)) {
-		// windows
-		if (strstr(buffer, "Name") || (strlen(buffer) == 2))
-			continue;
-		else if (sscanf(buffer, "%[^\n]", user_info->gpu_model[gpuc]))
-			gpuc++;
-	}
-	fclose(gpu);
+  // get all the gpus
+  while (fgets(buffer, BUFFER_SIZE, gpu)) {
+    // windows
+    if (strstr(buffer, "Name") || (strlen(buffer) == 2))
+      continue;
+    else if (sscanf(buffer, "%[^\n]", user_info->gpu_model[gpuc]))
+      gpuc++;
+  }
+  fclose(gpu);
 
-	// format gpu names
-	for (int i = 0; i < gpuc; i++) {
-		remove_brackets(user_info->gpu_model[i]);
-		truncate_str(user_info->gpu_model[i], user_info->target_width);
-		LOG_V(user_info->gpu_model[i]);
-	}
-	return 0;
+  // format gpu names
+  for (int i = 0; i < gpuc; i++) {
+    remove_brackets(user_info->gpu_model[i]);
+    truncate_str(user_info->gpu_model[i], user_info->target_width);
+    LOG_V(user_info->gpu_model[i]);
+  }
+  return 0;
 }
 
 // tries to get screen resolution
 #ifndef _WIN32
 void* get_res(void* argp) {
-	if (!((struct thread_varg*)argp)->thread_flags[3]) return 0;
-	LOG_I("getting resolution");
-	char* buffer					 = ((struct thread_varg*)argp)->buffer;
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
-	FILE* resolution			 = popen("xwininfo -root 2> /dev/null | grep -E 'Width|Height'", "r");
-	while (fgets(buffer, BUFFER_SIZE, resolution)) {
-		sscanf(buffer, "  Width: %d", &user_info->screen_width);
-		sscanf(buffer, "  Height: %d", &user_info->screen_height);
-	}
-	LOG_V(user_info->screen_width);
-	LOG_V(user_info->screen_height);
+  if (!((struct thread_varg*)argp)->thread_flags[3]) return 0;
+  LOG_I("getting resolution");
+  char* buffer           = ((struct thread_varg*)argp)->buffer;
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  FILE* resolution       = popen("xwininfo -root 2> /dev/null | grep -E 'Width|Height'", "r");
+  while (fgets(buffer, BUFFER_SIZE, resolution)) {
+    sscanf(buffer, "  Width: %d", &user_info->screen_width);
+    sscanf(buffer, "  Height: %d", &user_info->screen_height);
+  }
+  LOG_V(user_info->screen_width);
+  LOG_V(user_info->screen_height);
 #else
 void* get_res() {
-	// TODO: get resolution on windows
+  // TODO: get resolution on windows
 #endif
-	return 0;
+  return 0;
 }
 
 // tries to get the installed package count and package managers name
 void* get_pkg(void* argp) { // this is just a function that returns the total of installed packages
-	if (!((struct thread_varg*)argp)->thread_flags[4]) return 0;
-	LOG_I("getting pkgs");
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
-	user_info->pkgs				 = 0;
+  if (!((struct thread_varg*)argp)->thread_flags[4]) return 0;
+  LOG_I("getting pkgs");
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  user_info->pkgs        = 0;
 #ifndef __APPLE__
-	#ifndef _WIN32
-	// all supported package managers
-	struct package_manager pkgmans[] = {
-			{PKGPATH "apt", "apt list --installed 2> /dev/null | wc -l", "(apt)"},
-			{PKGPATH "apk", "apk info 2> /dev/null | wc -l", "(apk)"},
-			// {PKGPATH"dnf","dnf list installed 2> /dev/null | wc -l", "(dnf)"}, // according to https://stackoverflow.com/questions/48570019/advantages-of-dnf-vs-rpm-on-fedora, dnf and rpm return the same number of packages
-			{PKGPATH "qlist", "qlist -I 2> /dev/null | wc -l", "(emerge)"},
-			{PKGPATH "flatpak", "flatpak list 2> /dev/null | wc -l", "(flatpak)"},
-			{PKGPATH "snap", "snap list 2> /dev/null | wc -l", "(snap)"},
-			{PKGPATH "guix", "guix package --list-installed 2> /dev/null | wc -l", "(guix)"},
-			{PKGPATH "nix-store", "nix-store -q --requisites /run/current-system/sw 2> /dev/null | wc -l", "(nix)"},
-			{PKGPATH "pacman", "pacman -Qq 2> /dev/null | wc -l", "(pacman)"},
-			{PKGPATH "pkg", "pkg info 2>/dev/null | wc -l", "(pkg)"},
-			{PKGPATH "pkg_info", "pkg_info 2>/dev/null | wc -l | sed \"s/ //g\"", "(pkg)"},
-			{PKGPATH "port", "port installed 2> /dev/null | tail -n +2 | wc -l", "(port)"},
-			{PKGPATH "brew", "find $(brew --cellar 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}'", "(brew-cellar)"},
-			{PKGPATH "brew", "find $(brew --caskroom 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}'", "(brew-cask)"},
-			{PKGPATH "rpm", "rpm -qa --last 2> /dev/null | wc -l", "(rpm)"},
-			{PKGPATH "xbps-query", "xbps-query -l 2> /dev/null | wc -l", "(xbps)"},
-			{PKGPATH "zypper", "zypper -q se --installed-only 2> /dev/null | wc -l", "(zypper)"}};
-	#endif
+  #ifndef _WIN32
+  // all supported package managers
+  struct package_manager pkgmans[] = {
+      {PKGPATH "apt", "apt list --installed 2> /dev/null | wc -l", "(apt)"},
+      {PKGPATH "apk", "apk info 2> /dev/null | wc -l", "(apk)"},
+      // {PKGPATH"dnf","dnf list installed 2> /dev/null | wc -l", "(dnf)"}, // according to https://stackoverflow.com/questions/48570019/advantages-of-dnf-vs-rpm-on-fedora, dnf and rpm return the same number of packages
+      {PKGPATH "qlist", "qlist -I 2> /dev/null | wc -l", "(emerge)"},
+      {PKGPATH "flatpak", "flatpak list 2> /dev/null | wc -l", "(flatpak)"},
+      {PKGPATH "snap", "snap list 2> /dev/null | wc -l", "(snap)"},
+      {PKGPATH "guix", "guix package --list-installed 2> /dev/null | wc -l", "(guix)"},
+      {PKGPATH "nix-store", "nix-store -q --requisites /run/current-system/sw 2> /dev/null | wc -l", "(nix)"},
+      {PKGPATH "pacman", "pacman -Qq 2> /dev/null | wc -l", "(pacman)"},
+      {PKGPATH "pkg", "pkg info 2>/dev/null | wc -l", "(pkg)"},
+      {PKGPATH "pkg_info", "pkg_info 2>/dev/null | wc -l | sed \"s/ //g\"", "(pkg)"},
+      {PKGPATH "port", "port installed 2> /dev/null | tail -n +2 | wc -l", "(port)"},
+      {PKGPATH "brew", "find $(brew --cellar 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}'", "(brew-cellar)"},
+      {PKGPATH "brew", "find $(brew --caskroom 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}'", "(brew-cask)"},
+      {PKGPATH "rpm", "rpm -qa --last 2> /dev/null | wc -l", "(rpm)"},
+      {PKGPATH "xbps-query", "xbps-query -l 2> /dev/null | wc -l", "(xbps)"},
+      {PKGPATH "zypper", "zypper -q se --installed-only 2> /dev/null | wc -l", "(zypper)"}};
+  #endif
 #else
-	struct package_manager pkgmans[] = {{"/usr/local/bin/brew", "find $(brew --cellar 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}' > /tmp/uwufetch_brew_tmp", "(brew-cellar)"},
-																			{"/usr/local/bin/brew", "find $(brew --caskroom 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}' > /tmp/uwufetch_brew_tmp", "(brew-cask)"}};
+  struct package_manager pkgmans[] = {{"/usr/local/bin/brew", "find $(brew --cellar 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}' > /tmp/uwufetch_brew_tmp", "(brew-cellar)"},
+                                      {"/usr/local/bin/brew", "find $(brew --caskroom 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}' > /tmp/uwufetch_brew_tmp", "(brew-cask)"}};
 #endif
 #ifndef _WIN32
-	const int pkgman_count = sizeof(pkgmans) / sizeof(pkgmans[0]); // number of package managers
-	int comma_separator		 = 0;
-	for (int i = 0; i < pkgman_count; i++) {
-		struct package_manager* current = &pkgmans[i]; // pointer to current package manager
+  const int pkgman_count = sizeof(pkgmans) / sizeof(pkgmans[0]); // number of package managers
+  int comma_separator    = 0;
+  for (int i = 0; i < pkgman_count; i++) {
+    struct package_manager* current = &pkgmans[i]; // pointer to current package manager
 
-		unsigned int pkg_count = 0;
-		LOG_I("trying pkgman %d: %s", i, current->pkgman_name);
-		LOG_V(current->command_path);
-		if (access(current->command_path, F_OK) != -1) {
-	#ifndef __APPLE__
-			FILE* fp = popen(current->command_string, "r"); // trying current package manager
-	#else
-			system(current->command_string); // writes to a temporary file: for some reason popen() does not intercept the stdout, so i have to read from a temporary file
-			FILE* fp = fopen("/tmp/uwufetch_brew_tmp", "r");
-	#endif
-			if (fscanf(fp, "%u", &pkg_count) == 3) continue;
+    unsigned int pkg_count = 0;
+    LOG_I("trying pkgman %d: %s", i, current->pkgman_name);
+    LOG_V(current->command_path);
+    if (access(current->command_path, F_OK) != -1) {
+  #ifndef __APPLE__
+      FILE* fp = popen(current->command_string, "r"); // trying current package manager
+  #else
+      system(current->command_string); // writes to a temporary file: for some reason popen() does not intercept the stdout, so i have to read from a temporary file
+      FILE* fp = fopen("/tmp/uwufetch_brew_tmp", "r");
+  #endif
+      if (fscanf(fp, "%u", &pkg_count) == 3) continue;
 
-	#ifndef __APPLE__
-			pclose(fp);
-	#else
-			// remove("/tmp/uwufetch_brew_tmp");
-			fclose(fp);
-	#endif
-		}
-	#ifdef __DEBUG__
-		else
-			LOG_W("pkgman %s executable not found!", current->pkgman_name);
-	#endif
+  #ifndef __APPLE__
+      pclose(fp);
+  #else
+      // remove("/tmp/uwufetch_brew_tmp");
+      fclose(fp);
+  #endif
+    }
+  #ifdef __DEBUG__
+    else
+      LOG_W("pkgman %s executable not found!", current->pkgman_name);
+  #endif
 
-		// adding a package manager with its package count to user_info->pkgman_name
-		user_info->pkgs += pkg_count;
-		if (pkg_count > 0) {
-			if (comma_separator++) strcat(user_info->pkgman_name, ", ");
-			char spkg_count[16];
-			sprintf(spkg_count, "%u", pkg_count);
-			strcat(user_info->pkgman_name, spkg_count);
-			strcat(user_info->pkgman_name, " ");
-			strcat(user_info->pkgman_name, current->pkgman_name);
-			LOG_V(user_info->pkgman_name);
-		}
-	}
-#else	 // _WIN32
-	// chocolatey for windows
-	FILE* fp = popen("choco list -l --no-color 2> nul", "r");
-	unsigned int pkg_count;
-	char buffer[7562] = {0};
-	while (fgets(buffer, BUFFER_SIZE, fp)) {
-		sscanf(buffer, "%u packages installed.", &pkg_count);
-	}
-	if (fp) pclose(fp);
+    // adding a package manager with its package count to user_info->pkgman_name
+    user_info->pkgs += pkg_count;
+    if (pkg_count > 0) {
+      if (comma_separator++) strcat(user_info->pkgman_name, ", ");
+      char spkg_count[16];
+      sprintf(spkg_count, "%u", pkg_count);
+      strcat(user_info->pkgman_name, spkg_count);
+      strcat(user_info->pkgman_name, " ");
+      strcat(user_info->pkgman_name, current->pkgman_name);
+      LOG_V(user_info->pkgman_name);
+    }
+  }
+#else  // _WIN32
+  // chocolatey for windows
+  FILE* fp = popen("choco list -l --no-color 2> nul", "r");
+  unsigned int pkg_count;
+  char buffer[7562] = {0};
+  while (fgets(buffer, BUFFER_SIZE, fp)) {
+    sscanf(buffer, "%u packages installed.", &pkg_count);
+  }
+  if (fp) pclose(fp);
 
-	user_info->pkgs = pkg_count;
-	char spkg_count[16];
-	sprintf(spkg_count, "%u", pkg_count);
-	strcat(user_info->pkgman_name, spkg_count);
-	strcat(user_info->pkgman_name, " ");
-	strcat(user_info->pkgman_name, "(chocolatey)");
-	LOG_V(user_info->pkgman_name);
+  user_info->pkgs = pkg_count;
+  char spkg_count[16];
+  sprintf(spkg_count, "%u", pkg_count);
+  strcat(user_info->pkgman_name, spkg_count);
+  strcat(user_info->pkgman_name, " ");
+  strcat(user_info->pkgman_name, "(chocolatey)");
+  LOG_V(user_info->pkgman_name);
 #endif // _WIN32
-	return 0;
+  return 0;
 }
 
 void* get_model(void* argp) {
-	if (!((struct thread_varg*)argp)->thread_flags[5]) return 0;
-	LOG_I("getting model");
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
-	char* buffer					 = ((struct thread_varg*)argp)->buffer;
-	FILE* model_fp;
+  if (!((struct thread_varg*)argp)->thread_flags[5]) return 0;
+  LOG_I("getting model");
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  char* buffer           = ((struct thread_varg*)argp)->buffer;
+  FILE* model_fp;
 #ifdef _WIN32
-	// all the previous files obviously did not exist on windows
-	model_fp = popen("wmic computersystem get model", "r");
-	while (fgets(buffer, BUFFER_SIZE, model_fp)) {
-		if (strstr(buffer, "Model") != 0)
-			continue;
-		else {
-			sprintf(user_info->model, "%s", buffer);
-			user_info->model[strlen(user_info->model) - 2] = '\0';
-			break;
-		}
-	}
+  // all the previous files obviously did not exist on windows
+  model_fp = popen("wmic computersystem get model", "r");
+  while (fgets(buffer, BUFFER_SIZE, model_fp)) {
+    if (strstr(buffer, "Model") != 0)
+      continue;
+    else {
+      sprintf(user_info->model, "%s", buffer);
+      user_info->model[strlen(user_info->model) - 2] = '\0';
+      break;
+    }
+  }
 #elif defined(__BSD__) || defined(__APPLE__)
-	#if defined(__BSD__) && !defined(__OPENBSD__)
-		#define HOSTCTL "hw.hv_vendor"
-	#elif defined(__APPLE__)
-		#define HOSTCTL "hw.model"
-	#elif defined(__OPENBSD__)
-		#define HOSTCTL "hw.product"
-	#endif
-	model_fp = popen("sysctl " HOSTCTL, "r");
-	while (fgets(buffer, BUFFER_SIZE, model_fp))
-		if (sscanf(buffer,
-							 HOSTCTL
-	#ifdef __OPENBSD__
-							 "="
-	#else
-							 ": "
-	#endif
-							 "%[^\n]",
-							 user_info->model))
-			break;
-	pclose(model_fp);
+  #if defined(__BSD__) && !defined(__OPENBSD__)
+    #define HOSTCTL "hw.hv_vendor"
+  #elif defined(__APPLE__)
+    #define HOSTCTL "hw.model"
+  #elif defined(__OPENBSD__)
+    #define HOSTCTL "hw.product"
+  #endif
+  model_fp = popen("sysctl " HOSTCTL, "r");
+  while (fgets(buffer, BUFFER_SIZE, model_fp))
+    if (sscanf(buffer,
+               HOSTCTL
+  #ifdef __OPENBSD__
+               "="
+  #else
+               ": "
+  #endif
+               "%[^\n]",
+               user_info->model))
+      break;
+  pclose(model_fp);
 #else
-	char model_filename[4][256] = {
-			"/sys/devices/virtual/dmi/id/product_version",
-			"/sys/devices/virtual/dmi/id/product_name",
-			"/sys/devices/virtual/dmi/id/board_name",
-			"getprop ro.product.vendor.marketname 2>/dev/null",
-	};
+  char model_filename[4][256] = {
+      "/sys/devices/virtual/dmi/id/product_version",
+      "/sys/devices/virtual/dmi/id/product_name",
+      "/sys/devices/virtual/dmi/id/board_name",
+      "getprop ro.product.vendor.marketname 2>/dev/null",
+  };
 
-	char tmp_model[4][BUFFER_SIZE] = {0}; // temporary variable to store the contents of all 3 files
-	int longest_model = 0, best_len = 0, currentlen = 0;
-	FILE* (*tocall[])(const char*, const char*) = {fopen, fopen, fopen, popen}; // open a process or a file, depending on the model_filename
-	int (*tocall_close[])(FILE*)								= {fclose, fclose, fclose, pclose};
-	for (int i = 0; i < 4; i++) {
-		// read file
-		model_fp = tocall[i](model_filename[i], "r");
-		if (model_fp) {
-			fgets(tmp_model[i], BUFFER_SIZE, model_fp);
-			tmp_model[i][strlen(tmp_model[i]) - 1] = '\0';
-			tocall_close[i](model_fp);
-		}
-		LOG_V(tmp_model[i]);
-		// choose the file with the longest name
-		currentlen = strlen(tmp_model[i]);
-		if (currentlen > best_len) {
-			best_len			= currentlen;
-			longest_model = i;
-		}
-	}
-	if (strlen(tmp_model[longest_model]) == 0) {
-		model_fp = popen("lscpu 2>/dev/null", "r");
-		while (fgets(buffer, BUFFER_SIZE, model_fp))
-			if (sscanf(buffer, "Model name:%*[           |		]%[^\n]", tmp_model[longest_model]) == 1) break;
-		pclose(model_fp);
-		LOG_V(tmp_model[longest_model]);
-		if (strcmp(tmp_model[longest_model], "Icestorm") == 0) sprintf(tmp_model[longest_model], "Apple MacBook Air (M1)");
-	}
-	sprintf(user_info->model, "%s", tmp_model[longest_model]);
-	LOG_V(user_info->model);
+  char tmp_model[4][BUFFER_SIZE] = {0}; // temporary variable to store the contents of all 3 files
+  int longest_model = 0, best_len = 0, currentlen = 0;
+  FILE* (*tocall[])(const char*, const char*) = {fopen, fopen, fopen, popen}; // open a process or a file, depending on the model_filename
+  int (*tocall_close[])(FILE*)                = {fclose, fclose, fclose, pclose};
+  for (int i = 0; i < 4; i++) {
+    // read file
+    model_fp = tocall[i](model_filename[i], "r");
+    if (model_fp) {
+      fgets(tmp_model[i], BUFFER_SIZE, model_fp);
+      tmp_model[i][strlen(tmp_model[i]) - 1] = '\0';
+      tocall_close[i](model_fp);
+    }
+    LOG_V(tmp_model[i]);
+    // choose the file with the longest name
+    currentlen = strlen(tmp_model[i]);
+    if (currentlen > best_len) {
+      best_len      = currentlen;
+      longest_model = i;
+    }
+  }
+  if (strlen(tmp_model[longest_model]) == 0) {
+    model_fp = popen("lscpu 2>/dev/null", "r");
+    while (fgets(buffer, BUFFER_SIZE, model_fp))
+      if (sscanf(buffer, "Model name:%*[           |		]%[^\n]", tmp_model[longest_model]) == 1) break;
+    pclose(model_fp);
+    LOG_V(tmp_model[longest_model]);
+    if (strcmp(tmp_model[longest_model], "Icestorm") == 0) sprintf(tmp_model[longest_model], "Apple MacBook Air (M1)");
+  }
+  sprintf(user_info->model, "%s", tmp_model[longest_model]);
+  LOG_V(user_info->model);
 #endif
-	return 0;
+  return 0;
 }
 
 void* get_ker(void* argp) {
-	if (!((struct thread_varg*)argp)->thread_flags[6]) return 0;
-	LOG_I("getting kernel");
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  if (!((struct thread_varg*)argp)->thread_flags[6]) return 0;
+  LOG_I("getting kernel");
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
 
 #ifndef _WIN32
-	truncate_str(user_info->sys_var.release, user_info->target_width);
-	sprintf(user_info->kernel, "%s %s %s", user_info->sys_var.sysname, user_info->sys_var.release, user_info->sys_var.machine); // kernel name
-	truncate_str(user_info->kernel, user_info->target_width);
-	LOG_V(user_info->kernel);
-#else	 // _WIN32
-	// windows version
-	FILE* kernel_fp = popen("wmic computersystem get systemtype", "r");
-	char* buffer		= ((struct thread_varg*)argp)->buffer;
-	while (fgets(buffer, BUFFER_SIZE, kernel_fp)) {
-		if (strstr(buffer, "SystemType") != 0)
-			continue;
-		else {
-			sprintf(user_info->kernel, "%s", buffer);
-			user_info->kernel[strlen(user_info->kernel) - 2] = '\0';
-			break;
-		}
-	}
-	if (kernel_fp) pclose(kernel_fp);
+  truncate_str(user_info->sys_var.release, user_info->target_width);
+  sprintf(user_info->kernel, "%s %s %s", user_info->sys_var.sysname, user_info->sys_var.release, user_info->sys_var.machine); // kernel name
+  truncate_str(user_info->kernel, user_info->target_width);
+  LOG_V(user_info->kernel);
+#else  // _WIN32
+  // windows version
+  FILE* kernel_fp = popen("wmic computersystem get systemtype", "r");
+  char* buffer    = ((struct thread_varg*)argp)->buffer;
+  while (fgets(buffer, BUFFER_SIZE, kernel_fp)) {
+    if (strstr(buffer, "SystemType") != 0)
+      continue;
+    else {
+      sprintf(user_info->kernel, "%s", buffer);
+      user_info->kernel[strlen(user_info->kernel) - 2] = '\0';
+      break;
+    }
+  }
+  if (kernel_fp) pclose(kernel_fp);
 #endif // _WIN32
-	return 0;
+  return 0;
 }
 
 void* get_upt(void* argp) {
-	LOG_V(((struct thread_varg*)argp)->thread_flags[7]);
-	if (!((struct thread_varg*)argp)->thread_flags[7]) return 0;
-	LOG_I("getting uptime");
-	struct info* user_info = ((struct thread_varg*)argp)->user_info;
+  LOG_V(((struct thread_varg*)argp)->thread_flags[7]);
+  if (!((struct thread_varg*)argp)->thread_flags[7]) return 0;
+  LOG_I("getting uptime");
+  struct info* user_info = ((struct thread_varg*)argp)->user_info;
 #ifdef __APPLE__
-	int mib[2] = {CTL_KERN, KERN_BOOTTIME};
-	sysctl(mib, 2, &time_buffer, &time_buffer_len, NULL, 0);
+  int mib[2] = {CTL_KERN, KERN_BOOTTIME};
+  sysctl(mib, 2, &time_buffer, &time_buffer_len, NULL, 0);
 
-	time_t bsec = time_buffer.tv_sec;
-	time_t csec = time(NULL);
+  time_t bsec = time_buffer.tv_sec;
+  time_t csec = time(NULL);
 
-	user_info->uptime = difftime(csec, bsec);
+  user_info->uptime = difftime(csec, bsec);
 #else
-	#ifdef __BSD__
-	// https://github.com/coreutils/coreutils/blob/master/src/uptime.c
-	int boot_time					= 0;
-	static int request[2] = {CTL_KERN, KERN_BOOTTIME};
-	struct timeval result;
-	size_t result_len = sizeof result;
+  #ifdef __BSD__
+  // https://github.com/coreutils/coreutils/blob/master/src/uptime.c
+  int boot_time         = 0;
+  static int request[2] = {CTL_KERN, KERN_BOOTTIME};
+  struct timeval result;
+  size_t result_len = sizeof result;
 
-	if (sysctl(request, 2, &result, &result_len, NULL, 0) >= 0) boot_time = result.tv_sec;
-	int time_now			= time(NULL);
-	user_info->uptime = time_now - boot_time;
-	#else
-		#ifdef _WIN32
-	user_info->uptime = GetTickCount() / 1000;
-		#else	 // _WIN32
-	user_info->uptime = user_info->sys.uptime;
-		#endif // _WIN32
-	#endif
+  if (sysctl(request, 2, &result, &result_len, NULL, 0) >= 0) boot_time = result.tv_sec;
+  int time_now      = time(NULL);
+  user_info->uptime = time_now - boot_time;
+  #else
+    #ifdef _WIN32
+  user_info->uptime = GetTickCount() / 1000;
+    #else  // _WIN32
+  user_info->uptime = user_info->sys.uptime;
+    #endif // _WIN32
+  #endif
 #endif
-	LOG_V(user_info->uptime);
-	return 0;
+  LOG_V(user_info->uptime);
+  return 0;
 }
 
 // Retrieves system information
 void get_info(struct flags flags, struct info* user_info) {
-	char buffer[BUFFER_SIZE]; // line buffer
-	get_twidth(user_info);
-	// os version, cpu and board info
+  char buffer[BUFFER_SIZE]; // line buffer
+  get_twidth(user_info);
+  // os version, cpu and board info
 #ifdef __OPENBSD__
-	FILE* os_release = popen("echo ID=openbsd", "r"); // os-release does not exist in OpenBSD
+  FILE* os_release = popen("echo ID=openbsd", "r"); // os-release does not exist in OpenBSD
 #else
-	FILE* os_release	= fopen("/etc/os-release", "r"); // os name file
+  FILE* os_release  = fopen("/etc/os-release", "r"); // os name file
 #endif
 #ifndef __BSD__
-	FILE* cpuinfo = fopen("/proc/cpuinfo", "r"); // cpu name file for not-freebsd systems
+  FILE* cpuinfo = fopen("/proc/cpuinfo", "r"); // cpu name file for not-freebsd systems
 #else
-	FILE* cpuinfo			= popen("sysctl hw.model", "r"); // cpu name command for freebsd
+  FILE* cpuinfo     = popen("sysctl hw.model", "r"); // cpu name command for freebsd
 #endif
-	// trying to get some kind of information about the name of the computer (hopefully a product full name)
-	if (os_release) { // get normal vars if os_release exists
-		if (flags.os) {
-			LOG_I("getting os name from /etc/os-release");
-			while (fgets(buffer, BUFFER_SIZE, os_release) &&
-						 !(sscanf(buffer, "\nID=\"%s\"", user_info->os_name) ||
-							 sscanf(buffer, "\nID=%s", user_info->os_name)))
-				;
-			// sometimes for some reason sscanf reads the last '\"' too
-			int os_name_len = strlen(user_info->os_name);
-			if (user_info->os_name[os_name_len - 1] == '\"') {
-				user_info->os_name[os_name_len - 1] = '\0';
-			}
-			// trying to detect amogos because in its os-release file ID value is just "debian", will be removed when amogos will have an os-release file with ID=amogos
-			if (strcmp(user_info->os_name, "debian") == 0 ||
-					strcmp(user_info->os_name, "raspbian") == 0) {
-				DIR* amogos_plymouth = opendir("/usr/share/plymouth/themes/amogos");
-				if (amogos_plymouth) {
-					closedir(amogos_plymouth);
-					sprintf(user_info->os_name, "amogos");
-					LOG_V(user_info->os_name);
-				}
-			}
-			LOG_V(user_info->os_name);
-		}
-	} else { // try for android vars, next for Apple var, or unknown system
-					 // android
-		DIR* system_app			 = opendir("/system/app/");
-		DIR* system_priv_app = opendir("/system/priv-app/");
-		DIR* library				 = opendir("/Library/");
-		if (system_app && system_priv_app) {
-			closedir(system_app);
-			closedir(system_priv_app);
-			if (flags.os) sprintf(user_info->os_name, "android");
-			LOG_V(user_info->os_name);
-			if (flags.user) {
-				// username
-				FILE* whoami = popen("whoami", "r");
-				if (fscanf(whoami, "%s", user_info->user) == 3) {
-				}
-				LOG_V(user_info->user);
-				pclose(whoami);
-			}
-		} else if (library) { // Apple
-			closedir(library);
+  // trying to get some kind of information about the name of the computer (hopefully a product full name)
+  if (os_release) { // get normal vars if os_release exists
+    if (flags.os) {
+      LOG_I("getting os name from /etc/os-release");
+      while (fgets(buffer, BUFFER_SIZE, os_release) &&
+             !(sscanf(buffer, "\nID=\"%s\"", user_info->os_name) ||
+               sscanf(buffer, "\nID=%s", user_info->os_name)))
+        ;
+      // sometimes for some reason sscanf reads the last '\"' too
+      int os_name_len = strlen(user_info->os_name);
+      if (user_info->os_name[os_name_len - 1] == '\"') {
+        user_info->os_name[os_name_len - 1] = '\0';
+      }
+      // trying to detect amogos because in its os-release file ID value is just "debian", will be removed when amogos will have an os-release file with ID=amogos
+      if (strcmp(user_info->os_name, "debian") == 0 ||
+          strcmp(user_info->os_name, "raspbian") == 0) {
+        DIR* amogos_plymouth = opendir("/usr/share/plymouth/themes/amogos");
+        if (amogos_plymouth) {
+          closedir(amogos_plymouth);
+          sprintf(user_info->os_name, "amogos");
+          LOG_V(user_info->os_name);
+        }
+      }
+      LOG_V(user_info->os_name);
+    }
+  } else { // try for android vars, next for Apple var, or unknown system
+           // android
+    DIR* system_app      = opendir("/system/app/");
+    DIR* system_priv_app = opendir("/system/priv-app/");
+    DIR* library         = opendir("/Library/");
+    if (system_app && system_priv_app) {
+      closedir(system_app);
+      closedir(system_priv_app);
+      if (flags.os) sprintf(user_info->os_name, "android");
+      LOG_V(user_info->os_name);
+      if (flags.user) {
+        // username
+        FILE* whoami = popen("whoami", "r");
+        if (fscanf(whoami, "%s", user_info->user) == 3) {
+        }
+        LOG_V(user_info->user);
+        pclose(whoami);
+      }
+    } else if (library) { // Apple
+      closedir(library);
 #ifdef __APPLE__
-			if (flags.cpu) {
-				sysctlbyname("machdep.cpu.brand_string", &cpu_buffer, &cpu_buffer_len, NULL,
-										 0); // cpu name
-				sprintf(user_info->cpu_model, "%s", cpu_buffer);
-			}
-			if (flags.os) {
-	#ifndef __IPHONE__
-				sprintf(user_info->os_name, "macos");
-	#else
-				sprintf(user_info->os_name, "ios");
-	#endif
-			}
+      if (flags.cpu) {
+        sysctlbyname("machdep.cpu.brand_string", &cpu_buffer, &cpu_buffer_len, NULL,
+                     0); // cpu name
+        sprintf(user_info->cpu_model, "%s", cpu_buffer);
+      }
+      if (flags.os) {
+  #ifndef __IPHONE__
+        sprintf(user_info->os_name, "macos");
+  #else
+        sprintf(user_info->os_name, "ios");
+  #endif
+      }
 #endif
-		} else // if no option before is working, the system is unknown
-			sprintf(user_info->os_name, "unknown");
-	}
+    } else // if no option before is working, the system is unknown
+      sprintf(user_info->os_name, "unknown");
+  }
 #ifndef __BSD__
 #endif
 #ifndef _WIN32
-	// getting username and hostname
-	if (flags.user) {
-		LOG_I("getting username and hostname");
-		gethostname(user_info->host, 256);
-		LOG_V(user_info->host);
-		char* tmp_user = getenv("USER");
-		LOG_V(tmp_user);
-		if (tmp_user == NULL)
-			sprintf(user_info->user, "%s", "");
-		else
-			sprintf(user_info->user, "%s", tmp_user);
-		LOG_V(user_info->user);
-		if (os_release) fclose(os_release);
-	}
-	if (flags.shell) {
-		LOG_I("getting shell");
-		char* tmp_shell = getenv("SHELL"); // shell name
-		LOG_V(tmp_shell);
-		if (!tmp_shell)
-			sprintf(user_info->shell, "%s", "");
-		else
-			sprintf(user_info->shell, "%s", tmp_shell);
-	#ifdef __linux__
-		if (strlen(user_info->shell) > 16) // android shell name was too long
-			memmove(&user_info->shell, &user_info->shell[27], strlen(user_info->shell));
-	#endif
-		LOG_V(user_info->shell);
-	}
-#else	 // if _WIN32
-	// cpu name
-	if (flags.cpu) {
-		cpuinfo = popen("wmic cpu get caption", "r");
-		while (fgets(buffer, BUFFER_SIZE, cpuinfo)) {
-			if (strstr(buffer, "Caption") != 0)
-				continue;
-			else {
-				sprintf(user_info->cpu_model, "%s", buffer);
-				user_info->cpu_model[strlen(user_info->cpu_model) - 2] = '\0';
-				break;
-			}
-		}
-	}
-	// username
-	if (flags.user) {
-		FILE* user_host_fp = popen("wmic computersystem get username", "r");
-		while (fgets(buffer, BUFFER_SIZE, user_host_fp)) {
-			if (strstr(buffer, "UserName") != 0)
-				continue;
-			else {
-				sscanf(buffer, "%[^\\]%s", user_info->host, user_info->user);
-				memmove(user_info->user, user_info->user + 1, sizeof(user_info->user) - 1);
-				break;
-			}
-		}
-	}
-	// powershell version
-	if (flags.shell) {
-		FILE* shell_fp = popen("powershell $PSVersionTable", "r");
-		sprintf(user_info->shell, "PowerShell ");
-		char tmp_shell[64];
-		while (fgets(buffer, BUFFER_SIZE, shell_fp) &&
-					 sscanf(buffer, "PSVersion                      %s", tmp_shell) == 0)
-			;
-		strcat(user_info->shell, tmp_shell);
-	}
+  // getting username and hostname
+  if (flags.user) {
+    LOG_I("getting username and hostname");
+    gethostname(user_info->host, 256);
+    LOG_V(user_info->host);
+    char* tmp_user = getenv("USER");
+    LOG_V(tmp_user);
+    if (tmp_user == NULL)
+      sprintf(user_info->user, "%s", "");
+    else
+      sprintf(user_info->user, "%s", tmp_user);
+    LOG_V(user_info->user);
+    if (os_release) fclose(os_release);
+  }
+  if (flags.shell) {
+    LOG_I("getting shell");
+    char* tmp_shell = getenv("SHELL"); // shell name
+    LOG_V(tmp_shell);
+    if (!tmp_shell)
+      sprintf(user_info->shell, "%s", "");
+    else
+      sprintf(user_info->shell, "%s", tmp_shell);
+  #ifdef __linux__
+    if (strlen(user_info->shell) > 16) // android shell name was too long
+      memmove(&user_info->shell, &user_info->shell[27], strlen(user_info->shell));
+  #endif
+    LOG_V(user_info->shell);
+  }
+#else  // if _WIN32
+  // cpu name
+  if (flags.cpu) {
+    cpuinfo = popen("wmic cpu get caption", "r");
+    while (fgets(buffer, BUFFER_SIZE, cpuinfo)) {
+      if (strstr(buffer, "Caption") != 0)
+        continue;
+      else {
+        sprintf(user_info->cpu_model, "%s", buffer);
+        user_info->cpu_model[strlen(user_info->cpu_model) - 2] = '\0';
+        break;
+      }
+    }
+  }
+  // username
+  if (flags.user) {
+    FILE* user_host_fp = popen("wmic computersystem get username", "r");
+    while (fgets(buffer, BUFFER_SIZE, user_host_fp)) {
+      if (strstr(buffer, "UserName") != 0)
+        continue;
+      else {
+        sscanf(buffer, "%[^\\]%s", user_info->host, user_info->user);
+        memmove(user_info->user, user_info->user + 1, sizeof(user_info->user) - 1);
+        break;
+      }
+    }
+  }
+  // powershell version
+  if (flags.shell) {
+    FILE* shell_fp = popen("powershell $PSVersionTable", "r");
+    sprintf(user_info->shell, "PowerShell ");
+    char tmp_shell[64];
+    while (fgets(buffer, BUFFER_SIZE, shell_fp) &&
+           sscanf(buffer, "PSVersion                      %s", tmp_shell) == 0)
+      ;
+    strcat(user_info->shell, tmp_shell);
+  }
 #endif // _WIN32
 
 #ifdef _WIN32
-	if (flags.os) sprintf(user_info->os_name, "windows");
+  if (flags.os) sprintf(user_info->os_name, "windows");
 #endif
-	get_sys(user_info);
-	// are threads overpowered? nah
-	void* (*fnptrs[])(void*) = {get_cpu, get_ram, get_gpu, get_res, get_pkg, get_model, get_ker, get_upt};
-	struct thread_varg args =
-			(struct thread_varg){buffer,
-													 user_info,
-													 cpuinfo,
-													 {flags.cpu, flags.ram, flags.gpu, flags.resolution, flags.pkgs, flags.model, flags.kernel, flags.uptime}};
+  get_sys(user_info);
+  // are threads overpowered? nah
+  void* (*fnptrs[])(void*) = {get_cpu, get_ram, get_gpu, get_res, get_pkg, get_model, get_ker, get_upt};
+  struct thread_varg args =
+      (struct thread_varg){buffer,
+                           user_info,
+                           cpuinfo,
+                           {flags.cpu, flags.ram, flags.gpu, flags.resolution, flags.pkgs, flags.model, flags.kernel, flags.uptime}};
 #define THREAD_COUNT 8
 #ifndef _WIN32
-	pthread_t tids[THREAD_COUNT] = {0};
+  pthread_t tids[THREAD_COUNT] = {0};
 #endif
-	for (int i = 0; i < THREAD_COUNT; i++) {
-		LOG_I("STARTING thread %d", i);
+  for (int i = 0; i < THREAD_COUNT; i++) {
+    LOG_I("STARTING thread %d", i);
 #ifdef _WIN32
-		fnptrs[i](&args);
+    fnptrs[i](&args);
 #else
-		pthread_create(&tids[i], NULL, fnptrs[i], &args);
+    pthread_create(&tids[i], NULL, fnptrs[i], &args);
 #endif
-	}
+  }
 #ifndef _WIN32
-	for (int i = 0; i < THREAD_COUNT; i++) {
-		if (tids[i] != 0) pthread_join(tids[i], NULL);
-		LOG_I("JOINING thread %d", i);
-	}
+  for (int i = 0; i < THREAD_COUNT; i++) {
+    if (tids[i] != 0) pthread_join(tids[i], NULL);
+    LOG_I("JOINING thread %d", i);
+  }
 #endif
-	fclose(cpuinfo);
+  fclose(cpuinfo);
 }

--- a/fetch.h
+++ b/fetch.h
@@ -19,131 +19,131 @@
 
 #ifdef __DEBUG__
 bool* get_verbose_handle();
-	#ifdef LIBFETCH_INTERNAL
-		#define VERBOSE_ENABLED verbose_enabled
-	#else
-		#define VERBOSE_ENABLED *verbose_enabled
-	#endif
-	#define LOG_I(format, ...) LOG(0, format, ##__VA_ARGS__)
-	#define LOG_W(format, ...) LOG(1, format, ##__VA_ARGS__)
-	#define LOG_E(format, ...) LOG(2, format, ##__VA_ARGS__)
-	#define LOG_V(var)                       \
-		if (VERBOSE_ENABLED) {                 \
-			char format[1024] = "";              \
-			sprintf(format, "%s = %s", #var,     \
-							_Generic((var), int          \
-											 : "%d", float       \
-											 : "%f", char*       \
-											 : "\"%s\"", default \
-											 : "%p"));           \
-			LOG(3, format, var)                  \
-		}
-	#define LOG(type, format, ...)                      \
-		if (VERBOSE_ENABLED) {                            \
-			char buf[2048] = "";                            \
-			if (sizeof(#__VA_ARGS__) == sizeof(""))         \
-				sprintf(buf, "%s", format);                   \
-			else                                            \
-				sprintf(buf, format, ##__VA_ARGS__);          \
-			fprintf(stderr, "[%s]: %s in %s:%d: %s\n",      \
-							type == 0		? "\033[32mINFO\033[0m"     \
-							: type == 1 ? "\033[33mWARNING\033[0m"  \
-							: type == 2 ? "\033[31mERROR\033[0m"    \
-							: type == 3 ? "\033[37mVARIABLE\033[0m" \
-													: "",                       \
-							__func__, __FILE__, __LINE__, buf);     \
-		}
+  #ifdef LIBFETCH_INTERNAL
+    #define VERBOSE_ENABLED verbose_enabled
+  #else
+    #define VERBOSE_ENABLED *verbose_enabled
+  #endif
+  #define LOG_I(format, ...) LOG(0, format, ##__VA_ARGS__)
+  #define LOG_W(format, ...) LOG(1, format, ##__VA_ARGS__)
+  #define LOG_E(format, ...) LOG(2, format, ##__VA_ARGS__)
+  #define LOG_V(var)                       \
+    if (VERBOSE_ENABLED) {                 \
+      char format[1024] = "";              \
+      sprintf(format, "%s = %s", #var,     \
+              _Generic((var), int          \
+                       : "%d", float       \
+                       : "%f", char*       \
+                       : "\"%s\"", default \
+                       : "%p"));           \
+      LOG(3, format, var)                  \
+    }
+  #define LOG(type, format, ...)                      \
+    if (VERBOSE_ENABLED) {                            \
+      char buf[2048] = "";                            \
+      if (sizeof(#__VA_ARGS__) == sizeof(""))         \
+        sprintf(buf, "%s", format);                   \
+      else                                            \
+        sprintf(buf, format, ##__VA_ARGS__);          \
+      fprintf(stderr, "[%s]: %s in %s:%d: %s\n",      \
+              type == 0   ? "\033[32mINFO\033[0m"     \
+              : type == 1 ? "\033[33mWARNING\033[0m"  \
+              : type == 2 ? "\033[31mERROR\033[0m"    \
+              : type == 3 ? "\033[37mVARIABLE\033[0m" \
+                          : "",                       \
+              __func__, __FILE__, __LINE__, buf);     \
+    }
 #else
-	#define LOG_I(format, ...)
-	#define LOG_E(format, ...)
-	#define LOG_V(var)
-	#define LOG(type, format, ...)
+  #define LOG_I(format, ...)
+  #define LOG_E(format, ...)
+  #define LOG_V(var)
+  #define LOG(type, format, ...)
 #endif
 
 #ifndef LIBFETCH_INTERNAL
-	#ifdef __APPLE__
-		#include <TargetConditionals.h> // for checking iOS
-	#endif
-	#include <dirent.h>
-	#include <stdio.h>
-	#include <stdlib.h>
-	#include <string.h>
-	#include <unistd.h>
-	#if defined(__APPLE__) || defined(__BSD__)
-		#include <sys/sysctl.h>
-		#if defined(__OPENBSD__)
-			#include <sys/time.h>
-		#else
-			#include <time.h>
-		#endif // defined(__OPENBSD__)
-	#else		 // defined(__APPLE__) || defined(__BSD__)
-		#ifdef __BSD__
-		#else // defined(__BSD__) || defined(_WIN32)
-			#ifndef _WIN32
-				#ifndef __OPENBSD__
-					#include <sys/sysinfo.h>
-				#else	 // __OPENBSD__
-				#endif // __OPENBSD__
-			#else		 // _WIN32
-				#include <sysinfoapi.h>
-			#endif // _WIN32
-		#endif	 // defined(__BSD__) || defined(_WIN32)
-	#endif		 // defined(__APPLE__) || defined(__BSD__)
-	#ifndef _WIN32
-		#include <sys/ioctl.h>
-		#include <sys/utsname.h>
-		#include <pthread.h> // linux only right now
-	#else									 // _WIN32
-		#include <windows.h>
-	#endif // _WIN32
+  #ifdef __APPLE__
+    #include <TargetConditionals.h> // for checking iOS
+  #endif
+  #include <dirent.h>
+  #include <stdio.h>
+  #include <stdlib.h>
+  #include <string.h>
+  #include <unistd.h>
+  #if defined(__APPLE__) || defined(__BSD__)
+    #include <sys/sysctl.h>
+    #if defined(__OPENBSD__)
+      #include <sys/time.h>
+    #else
+      #include <time.h>
+    #endif // defined(__OPENBSD__)
+  #else    // defined(__APPLE__) || defined(__BSD__)
+    #ifdef __BSD__
+    #else // defined(__BSD__) || defined(_WIN32)
+      #ifndef _WIN32
+        #ifndef __OPENBSD__
+          #include <sys/sysinfo.h>
+        #else  // __OPENBSD__
+        #endif // __OPENBSD__
+      #else    // _WIN32
+        #include <sysinfoapi.h>
+      #endif // _WIN32
+    #endif   // defined(__BSD__) || defined(_WIN32)
+  #endif     // defined(__APPLE__) || defined(__BSD__)
+  #ifndef _WIN32
+    #include <pthread.h> // linux only right now
+    #include <sys/ioctl.h>
+    #include <sys/utsname.h>
+  #else // _WIN32
+    #include <windows.h>
+  #endif // _WIN32
 #endif
 
 // info that will be printed with the logo
 struct info {
-	char user[128],	 // username
-			host[256],	 // hostname (computer name)
-			shell[64],	 // shell name
-			model[256],	 // model name
-			kernel[256], // kernel name (linux 5.x-whatever)
-			os_name[64], // os name (arch linux, windows, mac os)
-			cpu_model[256], gpu_model[256][256],
-			pkgman_name[64], // package managers string
-			image_name[128];
-	int target_width, // for the truncate_str function
-			screen_width, screen_height, ram_total, ram_used,
-			pkgs; // full package count
-	long uptime;
+  char user[128],  // username
+      host[256],   // hostname (computer name)
+      shell[64],   // shell name
+      model[256],  // model name
+      kernel[256], // kernel name (linux 5.x-whatever)
+      os_name[64], // os name (arch linux, windows, mac os)
+      cpu_model[256], gpu_model[256][256],
+      pkgman_name[64], // package managers string
+      image_name[128];
+  int target_width, // for the truncate_str function
+      screen_width, screen_height, ram_total, ram_used,
+      pkgs; // full package count
+  long uptime;
 
 #ifndef _WIN32
-	struct utsname sys_var;
+  struct utsname sys_var;
 #endif // _WIN32
 #ifndef __APPLE__
-	#ifdef __linux__
-	struct sysinfo sys;
-	#else // __linux__
-		#ifdef _WIN32
-	struct _SYSTEM_INFO sys;
-		#endif // _WIN32
-	#endif	 // __linux__
-#endif		 // __APPLE__
+  #ifdef __linux__
+  struct sysinfo sys;
+  #else // __linux__
+    #ifdef _WIN32
+  struct _SYSTEM_INFO sys;
+    #endif // _WIN32
+  #endif   // __linux__
+#endif     // __APPLE__
 #ifndef _WIN32
-	struct winsize win;
-#else	 // _WIN32
-	int ws_col, ws_rows;
+  struct winsize win;
+#else  // _WIN32
+  int ws_col, ws_rows;
 #endif // _WIN32
 };
 
 // Args struct for get_something thread oriented functions
 struct thread_varg {
-	char* buffer;
-	struct info* user_info;
-	FILE* cpuinfo;
-	bool thread_flags[8];
+  char* buffer;
+  struct info* user_info;
+  FILE* cpuinfo;
+  bool thread_flags[8];
 };
 
 // decide what info should be retrieved
 struct flags {
-	bool user, shell, model, kernel, os, cpu, gpu, resolution, ram, pkgs, uptime;
+  bool user, shell, model, kernel, os, cpu, gpu, resolution, ram, pkgs, uptime;
 };
 
 void get_sys(struct info*);

--- a/release_scripts/install.sh
+++ b/release_scripts/install.sh
@@ -7,6 +7,6 @@ cp libfetch.so /usr/lib
 cp fetch.h /usr/include
 cp -r res/* /usr/lib/uwufetch
 cp default.config /etc/uwufetch/config
-cp ./uwufetch.1.gz /usr/share/man/man1
+cp ./uwufetch.1 /usr/share/man/man1
 printf "Done!\n"
 

--- a/release_scripts/uninstall.sh
+++ b/release_scripts/uninstall.sh
@@ -6,6 +6,6 @@ rm -rf /usr/lib/uwufetch
 rm -f /usr/lib/libfetch.so
 rm -f /usr/include/fetch.h
 rm -rf /etc/uwufetch
-rm -f /usr/share/man/man1/uwufetch.1.gz
+rm -f /usr/share/man/man1/uwufetch.1
 printf "Done!\n"
 

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -14,7 +14,7 @@
  */
 
 #ifndef UWUFETCH_VERSION
-	#define UWUFETCH_VERSION "unkown" // needs to be changed by the build script
+  #define UWUFETCH_VERSION "unkown" // needs to be changed by the build script
 #endif
 
 #define _GNU_SOURCE // for strcasestr
@@ -39,10 +39,10 @@
 #define LPINK "\x1b[38;5;213m"
 
 #ifdef _WIN32
-	#define BLOCK_CHAR "\xdb"			// block char for colors
+  #define BLOCK_CHAR "\xdb"     // block char for colors
 char* MOVE_CURSOR = "\033[21C"; // moves the cursor after printing the image or the ascii logo
 #else
-	#define BLOCK_CHAR "\u2587"
+  #define BLOCK_CHAR "\u2587"
 char* MOVE_CURSOR = "\033[18C";
 #endif // _WIN32
 
@@ -52,624 +52,624 @@ static bool* verbose_enabled = NULL;
 
 // all configuration flags available
 struct configuration {
-	struct flags show; // all true by default
-	bool show_image,	 // false by default
-			show_colors;	 // true by default
-	bool show_gpu[256];
-	bool show_gpus; // global gpu toggle
+  struct flags show; // all true by default
+  bool show_image,   // false by default
+      show_colors;   // true by default
+  bool show_gpu[256];
+  bool show_gpus; // global gpu toggle
 };
 
 // user's config stored on the disk
 struct user_config {
-	char *config_directory, // configuration directory name
-			*cache_content;			// cache file content
-	int read_enabled, write_enabled;
+  char *config_directory, // configuration directory name
+      *cache_content;     // cache file content
+  int read_enabled, write_enabled;
 };
 
 // reads the config file
 struct configuration parse_config(struct info* user_info, struct user_config* user_config_file) {
-	LOG_I("parsing config");
-	char buffer[256]; // buffer for the current line
-	// enabling all flags by default
-	struct configuration config_flags;
-	memset(&config_flags, true, sizeof(config_flags));
+  LOG_I("parsing config");
+  char buffer[256]; // buffer for the current line
+  // enabling all flags by default
+  struct configuration config_flags;
+  memset(&config_flags, true, sizeof(config_flags));
 
-	config_flags.show_image = false;
+  config_flags.show_image = false;
 
-	FILE* config = NULL; // config file pointer
+  FILE* config = NULL; // config file pointer
 
-	if (user_config_file->config_directory == NULL) { // if config directory is not set, try to open the default
-		if (getenv("HOME") != NULL) {
-			char homedir[512];
-			sprintf(homedir, "%s/.config/uwufetch/config", getenv("HOME"));
-			LOG_V(homedir);
-			config = fopen(homedir, "r");
-			if (!config) {
-				if (getenv("PREFIX") != NULL) {
-					char prefixed_etc[512];
-					sprintf(prefixed_etc, "%s/etc/uwufetch/config", getenv("PREFIX"));
-					LOG_V(prefixed_etc);
-					config = fopen(prefixed_etc, "r");
-				} else
-					config = fopen("/etc/uwufetch/config", "r");
-			}
-		}
-	} else
-		config = fopen(user_config_file->config_directory, "r");
-	if (config == NULL) return config_flags; // if config file does not exist, return the defaults
+  if (user_config_file->config_directory == NULL) { // if config directory is not set, try to open the default
+    if (getenv("HOME") != NULL) {
+      char homedir[512];
+      sprintf(homedir, "%s/.config/uwufetch/config", getenv("HOME"));
+      LOG_V(homedir);
+      config = fopen(homedir, "r");
+      if (!config) {
+        if (getenv("PREFIX") != NULL) {
+          char prefixed_etc[512];
+          sprintf(prefixed_etc, "%s/etc/uwufetch/config", getenv("PREFIX"));
+          LOG_V(prefixed_etc);
+          config = fopen(prefixed_etc, "r");
+        } else
+          config = fopen("/etc/uwufetch/config", "r");
+      }
+    }
+  } else
+    config = fopen(user_config_file->config_directory, "r");
+  if (config == NULL) return config_flags; // if config file does not exist, return the defaults
 
-	int gpu_cfg_count = 0;
+  int gpu_cfg_count = 0;
 
-	// reading the config file
-	while (fgets(buffer, sizeof(buffer), config)) {
-		sscanf(buffer, "distro=%s", user_info->os_name);
-		if (sscanf(buffer, "image=\"%[^\"]\"", user_info->image_name)) {
-			if (user_info->image_name[0] == '~') {																													// replacing the ~ character with the home directory
-				memmove(&user_info->image_name[0], &user_info->image_name[1], strlen(user_info->image_name)); // remove the first char
-				char temp[128] = "/home/";
-				strcat(temp, user_info->user);
-				strcat(temp, user_info->image_name);
-				sprintf(user_info->image_name, "%s", temp);
-			}
-			config_flags.show_image = 1; // enable the image flag
-		}
+  // reading the config file
+  while (fgets(buffer, sizeof(buffer), config)) {
+    sscanf(buffer, "distro=%s", user_info->os_name);
+    if (sscanf(buffer, "image=\"%[^\"]\"", user_info->image_name)) {
+      if (user_info->image_name[0] == '~') {                                                          // replacing the ~ character with the home directory
+        memmove(&user_info->image_name[0], &user_info->image_name[1], strlen(user_info->image_name)); // remove the first char
+        char temp[128] = "/home/";
+        strcat(temp, user_info->user);
+        strcat(temp, user_info->image_name);
+        sprintf(user_info->image_name, "%s", temp);
+      }
+      config_flags.show_image = 1; // enable the image flag
+    }
 
-		// reading other values
-		if (sscanf(buffer, "user=%[truefalse]", buffer)) {
-			config_flags.show.user = !strcmp(buffer, "true");
-			LOG_V(config_flags.show.user);
-		}
-		if (sscanf(buffer, "os=%[truefalse]", buffer)) {
-			config_flags.show.os = strcmp(buffer, "false");
-			LOG_V(config_flags.show.os);
-		}
-		if (sscanf(buffer, "host=%[truefalse]", buffer)) {
-			config_flags.show.model = strcmp(buffer, "false");
-			LOG_V(config_flags.show.model);
-		}
-		if (sscanf(buffer, "kernel=%[truefalse]", buffer)) {
-			config_flags.show.kernel = strcmp(buffer, "false");
-			LOG_V(config_flags.show.kernel);
-		}
-		if (sscanf(buffer, "cpu=%[truefalse]", buffer)) {
-			config_flags.show.cpu = strcmp(buffer, "false");
-			LOG_V(config_flags.show.cpu);
-		}
-		if (sscanf(buffer, "gpu=%d", &gpu_cfg_count)) {
-			if (gpu_cfg_count > 255) {
-				LOG_E("gpu config index is too high, setting it to 255");
-				gpu_cfg_count = 255;
-			} else if (gpu_cfg_count < 0) {
-				LOG_E("gpu config index is too low, setting it to 0");
-				gpu_cfg_count = 0;
-			}
-			config_flags.show_gpu[gpu_cfg_count] = false;
-			LOG_V(config_flags.show_gpu[gpu_cfg_count]);
-		}
-		if (sscanf(buffer, "gpus=%[truefalse]", buffer)) { // global gpu toggle
-			if (strcmp(buffer, "false") == 0) {
-				config_flags.show_gpus = false;
-				config_flags.show.gpu	 = false; // enable getting gpu info
-			} else {
-				config_flags.show_gpus = true;
-				config_flags.show.gpu	 = true;
-			}
-			LOG_V(config_flags.show_gpus);
-			LOG_V(config_flags.show.gpu);
-		}
-		if (sscanf(buffer, "ram=%[truefalse]", buffer)) {
-			config_flags.show.ram = strcmp(buffer, "false");
-			LOG_V(config_flags.show.ram);
-		}
-		if (sscanf(buffer, "resolution=%[truefalse]", buffer)) {
-			config_flags.show.resolution = strcmp(buffer, "false");
-			LOG_V(config_flags.show.resolution);
-		}
-		if (sscanf(buffer, "shell=%[truefalse]", buffer)) {
-			config_flags.show.shell = strcmp(buffer, "false");
-			LOG_V(config_flags.show.shell);
-		}
-		if (sscanf(buffer, "pkgs=%[truefalse]", buffer)) {
-			config_flags.show.pkgs = strcmp(buffer, "false");
-			LOG_V(config_flags.show.pkgs);
-		}
-		if (sscanf(buffer, "uptime=%[truefalse]", buffer)) {
-			config_flags.show.uptime = strcmp(buffer, "false");
-			LOG_V(config_flags.show.uptime);
-		}
-		if (sscanf(buffer, "colors=%[truefalse]", buffer)) {
-			config_flags.show_colors = strcmp(buffer, "false");
-			LOG_V(config_flags.show_colors);
-		}
-	}
-	LOG_V(user_info->os_name);
-	LOG_V(user_info->image_name);
-	fclose(config);
-	return config_flags;
+    // reading other values
+    if (sscanf(buffer, "user=%[truefalse]", buffer)) {
+      config_flags.show.user = !strcmp(buffer, "true");
+      LOG_V(config_flags.show.user);
+    }
+    if (sscanf(buffer, "os=%[truefalse]", buffer)) {
+      config_flags.show.os = strcmp(buffer, "false");
+      LOG_V(config_flags.show.os);
+    }
+    if (sscanf(buffer, "host=%[truefalse]", buffer)) {
+      config_flags.show.model = strcmp(buffer, "false");
+      LOG_V(config_flags.show.model);
+    }
+    if (sscanf(buffer, "kernel=%[truefalse]", buffer)) {
+      config_flags.show.kernel = strcmp(buffer, "false");
+      LOG_V(config_flags.show.kernel);
+    }
+    if (sscanf(buffer, "cpu=%[truefalse]", buffer)) {
+      config_flags.show.cpu = strcmp(buffer, "false");
+      LOG_V(config_flags.show.cpu);
+    }
+    if (sscanf(buffer, "gpu=%d", &gpu_cfg_count)) {
+      if (gpu_cfg_count > 255) {
+        LOG_E("gpu config index is too high, setting it to 255");
+        gpu_cfg_count = 255;
+      } else if (gpu_cfg_count < 0) {
+        LOG_E("gpu config index is too low, setting it to 0");
+        gpu_cfg_count = 0;
+      }
+      config_flags.show_gpu[gpu_cfg_count] = false;
+      LOG_V(config_flags.show_gpu[gpu_cfg_count]);
+    }
+    if (sscanf(buffer, "gpus=%[truefalse]", buffer)) { // global gpu toggle
+      if (strcmp(buffer, "false") == 0) {
+        config_flags.show_gpus = false;
+        config_flags.show.gpu  = false; // enable getting gpu info
+      } else {
+        config_flags.show_gpus = true;
+        config_flags.show.gpu  = true;
+      }
+      LOG_V(config_flags.show_gpus);
+      LOG_V(config_flags.show.gpu);
+    }
+    if (sscanf(buffer, "ram=%[truefalse]", buffer)) {
+      config_flags.show.ram = strcmp(buffer, "false");
+      LOG_V(config_flags.show.ram);
+    }
+    if (sscanf(buffer, "resolution=%[truefalse]", buffer)) {
+      config_flags.show.resolution = strcmp(buffer, "false");
+      LOG_V(config_flags.show.resolution);
+    }
+    if (sscanf(buffer, "shell=%[truefalse]", buffer)) {
+      config_flags.show.shell = strcmp(buffer, "false");
+      LOG_V(config_flags.show.shell);
+    }
+    if (sscanf(buffer, "pkgs=%[truefalse]", buffer)) {
+      config_flags.show.pkgs = strcmp(buffer, "false");
+      LOG_V(config_flags.show.pkgs);
+    }
+    if (sscanf(buffer, "uptime=%[truefalse]", buffer)) {
+      config_flags.show.uptime = strcmp(buffer, "false");
+      LOG_V(config_flags.show.uptime);
+    }
+    if (sscanf(buffer, "colors=%[truefalse]", buffer)) {
+      config_flags.show_colors = strcmp(buffer, "false");
+      LOG_V(config_flags.show_colors);
+    }
+  }
+  LOG_V(user_info->os_name);
+  LOG_V(user_info->image_name);
+  fclose(config);
+  return config_flags;
 }
 
 // prints logo (as an image) of the given system.
 int print_image(struct info* user_info) {
-	LOG_I("printing image");
+  LOG_I("printing image");
 #ifndef __IPHONE__
-	char command[256];
-	if (strlen(user_info->image_name) < 1) {
-		char* repl_str = strcmp(user_info->os_name, "android") == 0 ? "/data/data/com.termux/files/usr/lib/uwufetch/%s.png"
-										 : strcmp(user_info->os_name, "macos") == 0 ? "/usr/local/lib/uwufetch/%s.png"
-																																: "/usr/lib/uwufetch/%s.png";
-		sprintf(user_info->image_name, repl_str, user_info->os_name); // image command for android
-		LOG_V(user_info->image_name);
-	}
-	sprintf(command, "viu -t -w 18 -h 9 %s 2> /dev/null", user_info->image_name); // creating the command to show the image
-	LOG_V(command);
-	if (system(command) != 0) // if viu is not installed or the image is missing
-		printf("\033[0E\033[3C%s\n"
-					 "   There was an\n"
-					 "    error: viu\n"
-					 "  is not installed\n"
-					 " or the image file\n"
-					 "   was not found\n"
-					 "   see IMAGES.md\n"
-					 "   for more info.\n\n",
-					 RED);
+  char command[256];
+  if (strlen(user_info->image_name) < 1) {
+    char* repl_str = strcmp(user_info->os_name, "android") == 0 ? "/data/data/com.termux/files/usr/lib/uwufetch/%s.png"
+                     : strcmp(user_info->os_name, "macos") == 0 ? "/usr/local/lib/uwufetch/%s.png"
+                                                                : "/usr/lib/uwufetch/%s.png";
+    sprintf(user_info->image_name, repl_str, user_info->os_name); // image command for android
+    LOG_V(user_info->image_name);
+  }
+  sprintf(command, "viu -t -w 18 -h 9 %s 2> /dev/null", user_info->image_name); // creating the command to show the image
+  LOG_V(command);
+  if (system(command) != 0) // if viu is not installed or the image is missing
+    printf("\033[0E\033[3C%s\n"
+           "   There was an\n"
+           "    error: viu\n"
+           "  is not installed\n"
+           " or the image file\n"
+           "   was not found\n"
+           "   see IMAGES.md\n"
+           "   for more info.\n\n",
+           RED);
 #else
-	// unfortunately, the iOS stdlib does not have system(); because it reports that it is not available under iOS during compilation
-	printf("\033[0E\033[3C%s\n"
-				 "   There was an\n"
-				 "   error: images\n"
-				 "   are currently\n"
-				 "  disabled on iOS.\n\n",
-				 RED);
+  // unfortunately, the iOS stdlib does not have system(); because it reports that it is not available under iOS during compilation
+  printf("\033[0E\033[3C%s\n"
+         "   There was an\n"
+         "   error: images\n"
+         "   are currently\n"
+         "  disabled on iOS.\n\n",
+         RED);
 #endif
-	return 9;
+  return 9;
 }
 
 // Replaces all terms in a string with another term.
 void replace(char* original, char* search, char* replacer) {
-	char* ch;
-	char buffer[1024];
-	int offset = 0;
-	while ((ch = strstr(original + offset, search))) {
-		strncpy(buffer, original, ch - original);
-		buffer[ch - original] = 0;
-		sprintf(buffer + (ch - original), "%s%s", replacer, ch + strlen(search));
-		original[0] = 0;
-		strcpy(original, buffer);
-		offset = ch - original + strlen(replacer);
-	}
+  char* ch;
+  char buffer[1024];
+  int offset = 0;
+  while ((ch = strstr(original + offset, search))) {
+    strncpy(buffer, original, ch - original);
+    buffer[ch - original] = 0;
+    sprintf(buffer + (ch - original), "%s%s", replacer, ch + strlen(search));
+    original[0] = 0;
+    strcpy(original, buffer);
+    offset = ch - original + strlen(replacer);
+  }
 }
 
 // Replaces all terms in a string with another term, case insensitive
 void replace_ignorecase(char* original, char* search, char* replacer) {
-	char* ch;
-	char buffer[1024];
-	int offset = 0;
+  char* ch;
+  char buffer[1024];
+  int offset = 0;
 #ifdef _WIN32
-	#define strcasestr(o, s) strstr(o, s)
+  #define strcasestr(o, s) strstr(o, s)
 #endif
-	while ((ch = strcasestr(original + offset, search))) {
-		strncpy(buffer, original, ch - original);
-		buffer[ch - original] = 0;
-		sprintf(buffer + (ch - original), "%s%s", replacer, ch + strlen(search));
-		original[0] = 0;
-		strcpy(original, buffer);
-		offset = ch - original + strlen(replacer);
-	}
+  while ((ch = strcasestr(original + offset, search))) {
+    strncpy(buffer, original, ch - original);
+    buffer[ch - original] = 0;
+    sprintf(buffer + (ch - original), "%s%s", replacer, ch + strlen(search));
+    original[0] = 0;
+    strcpy(original, buffer);
+    offset = ch - original + strlen(replacer);
+  }
 }
 
 #ifdef _WIN32
 // windows sucks and hasn't a strstep, so I copied one from https://stackoverflow.com/questions/8512958/is-there-a-windows-variant-of-strsep-function
 char* strsep(char** stringp, const char* delim) {
-	char* start = *stringp;
-	char* p;
-	p = (start != NULL) ? strpbrk(start, delim) : NULL;
-	if (p == NULL)
-		*stringp = NULL;
-	else {
-		*p			 = '\0';
-		*stringp = p + 1;
-	}
-	return start;
+  char* start = *stringp;
+  char* p;
+  p = (start != NULL) ? strpbrk(start, delim) : NULL;
+  if (p == NULL)
+    *stringp = NULL;
+  else {
+    *p       = '\0';
+    *stringp = p + 1;
+  }
+  return start;
 }
 #endif
 
 // uwufies distro name
 void uwu_name(struct info* user_info) {
 #define STRING_TO_UWU(original, uwufied) \
-	if (strcmp(user_info->os_name, original) == 0) sprintf(user_info->os_name, "%s", uwufied)
-	// linux
-	STRING_TO_UWU("alpine", "Nyalpine");
-	else STRING_TO_UWU("amogos", "AmogOwOS");
-	else STRING_TO_UWU("android", "Nyandroid");
-	else STRING_TO_UWU("arch", "Nyarch Linuwu");
-	else STRING_TO_UWU("arcolinux", "ArcOwO Linuwu");
-	else STRING_TO_UWU("artix", "Nyartix Linuwu");
-	else STRING_TO_UWU("debian", "Debinyan");
-	else STRING_TO_UWU("devuan", "Devunyan");
-	else STRING_TO_UWU("deepin", "Dewepyn");
-	else STRING_TO_UWU("endeavouros", "endeavOwO");
-	else STRING_TO_UWU("EndeavourOS", "endeavOwO");
-	else STRING_TO_UWU("fedora", "Fedowa");
-	else STRING_TO_UWU("femboyos", "FemboyOWOS");
-	else STRING_TO_UWU("gentoo", "GentOwO");
-	else STRING_TO_UWU("gnu", "gnUwU");
-	else STRING_TO_UWU("guix", "gnUwU gUwUix");
-	else STRING_TO_UWU("linuxmint", "LinUWU Miwint");
-	else STRING_TO_UWU("manjaro", "Myanjawo");
-	else STRING_TO_UWU("manjaro-arm", "Myanjawo AWM");
-	else STRING_TO_UWU("neon", "KDE NeOwOn");
-	else STRING_TO_UWU("nixos", "nixOwOs");
-	else STRING_TO_UWU("opensuse-leap", "OwOpenSUSE Leap");
-	else STRING_TO_UWU("opensuse-tumbleweed", "OwOpenSUSE Tumbleweed");
-	else STRING_TO_UWU("pop", "PopOwOS");
-	else STRING_TO_UWU("raspbian", "RaspNyan");
-	else STRING_TO_UWU("rocky", "Wocky Linuwu");
-	else STRING_TO_UWU("slackware", "Swackwawe");
-	else STRING_TO_UWU("solus", "sOwOlus");
-	else STRING_TO_UWU("ubuntu", "Uwuntu");
-	else STRING_TO_UWU("void", "OwOid");
-	else STRING_TO_UWU("xerolinux", "xuwulinux");
+  if (strcmp(user_info->os_name, original) == 0) sprintf(user_info->os_name, "%s", uwufied)
+  // linux
+  STRING_TO_UWU("alpine", "Nyalpine");
+  else STRING_TO_UWU("amogos", "AmogOwOS");
+  else STRING_TO_UWU("android", "Nyandroid");
+  else STRING_TO_UWU("arch", "Nyarch Linuwu");
+  else STRING_TO_UWU("arcolinux", "ArcOwO Linuwu");
+  else STRING_TO_UWU("artix", "Nyartix Linuwu");
+  else STRING_TO_UWU("debian", "Debinyan");
+  else STRING_TO_UWU("devuan", "Devunyan");
+  else STRING_TO_UWU("deepin", "Dewepyn");
+  else STRING_TO_UWU("endeavouros", "endeavOwO");
+  else STRING_TO_UWU("EndeavourOS", "endeavOwO");
+  else STRING_TO_UWU("fedora", "Fedowa");
+  else STRING_TO_UWU("femboyos", "FemboyOWOS");
+  else STRING_TO_UWU("gentoo", "GentOwO");
+  else STRING_TO_UWU("gnu", "gnUwU");
+  else STRING_TO_UWU("guix", "gnUwU gUwUix");
+  else STRING_TO_UWU("linuxmint", "LinUWU Miwint");
+  else STRING_TO_UWU("manjaro", "Myanjawo");
+  else STRING_TO_UWU("manjaro-arm", "Myanjawo AWM");
+  else STRING_TO_UWU("neon", "KDE NeOwOn");
+  else STRING_TO_UWU("nixos", "nixOwOs");
+  else STRING_TO_UWU("opensuse-leap", "OwOpenSUSE Leap");
+  else STRING_TO_UWU("opensuse-tumbleweed", "OwOpenSUSE Tumbleweed");
+  else STRING_TO_UWU("pop", "PopOwOS");
+  else STRING_TO_UWU("raspbian", "RaspNyan");
+  else STRING_TO_UWU("rocky", "Wocky Linuwu");
+  else STRING_TO_UWU("slackware", "Swackwawe");
+  else STRING_TO_UWU("solus", "sOwOlus");
+  else STRING_TO_UWU("ubuntu", "Uwuntu");
+  else STRING_TO_UWU("void", "OwOid");
+  else STRING_TO_UWU("xerolinux", "xuwulinux");
 
-	// BSD
-	else STRING_TO_UWU("freebsd", "FweeBSD");
-	else STRING_TO_UWU("openbsd", "OwOpenBSD");
+  // BSD
+  else STRING_TO_UWU("freebsd", "FweeBSD");
+  else STRING_TO_UWU("openbsd", "OwOpenBSD");
 
-	// Apple family
-	else STRING_TO_UWU("macos", "macOwOS");
-	else STRING_TO_UWU("ios", "iOwOS");
+  // Apple family
+  else STRING_TO_UWU("macos", "macOwOS");
+  else STRING_TO_UWU("ios", "iOwOS");
 
-	// Windows
-	else STRING_TO_UWU("windows", "WinyandOwOws");
+  // Windows
+  else STRING_TO_UWU("windows", "WinyandOwOws");
 
-	else sprintf(user_info->os_name, "%s", "unknown");
+  else sprintf(user_info->os_name, "%s", "unknown");
 #undef STRING_TO_UWU
 }
 
 // uwufies kernel name
 void uwu_kernel(char* kernel) {
 #define KERNEL_TO_UWU(str, original, uwufied) \
-	if (strcmp(str, original) == 0) sprintf(str, "%s", uwufied)
+  if (strcmp(str, original) == 0) sprintf(str, "%s", uwufied)
 
-	LOG_I("uwufing kernel");
+  LOG_I("uwufing kernel");
 
-	char* temp_kernel = kernel;
-	char* token;
-	char splitted[16][128] = {};
+  char* temp_kernel = kernel;
+  char* token;
+  char splitted[16][128] = {};
 
-	int count = 0;
-	while ((token = strsep(&temp_kernel, " "))) { // split kernel name
-		strcpy(splitted[count], token);
-		count++;
-	}
-	strcpy(kernel, "");
-	for (int i = 0; i < 16; i++) {
-		// replace kernel name with uwufied version
-		KERNEL_TO_UWU(splitted[i], "Linux", "Linuwu");
-		else KERNEL_TO_UWU(splitted[i], "linux", "linuwu");
-		else KERNEL_TO_UWU(splitted[i], "alpine", "Nyalpine");
-		else KERNEL_TO_UWU(splitted[i], "amogos", "AmogOwOS");
-		else KERNEL_TO_UWU(splitted[i], "android", "Nyandroid");
-		else KERNEL_TO_UWU(splitted[i], "arch", "Nyarch Linuwu");
-		else KERNEL_TO_UWU(splitted[i], "artix", "Nyartix Linuwu");
-		else KERNEL_TO_UWU(splitted[i], "debian", "Debinyan");
-		else KERNEL_TO_UWU(splitted[i], "deepin", "Dewepyn");
-		else KERNEL_TO_UWU(splitted[i], "endeavouros", "endeavOwO");
-		else KERNEL_TO_UWU(splitted[i], "EndeavourOS", "endeavOwO");
-		else KERNEL_TO_UWU(splitted[i], "fedora", "Fedowa");
-		else KERNEL_TO_UWU(splitted[i], "femboyos", "FemboyOWOS");
-		else KERNEL_TO_UWU(splitted[i], "gentoo", "GentOwO");
-		else KERNEL_TO_UWU(splitted[i], "gnu", "gnUwU");
-		else KERNEL_TO_UWU(splitted[i], "guix", "gnUwU gUwUix");
-		else KERNEL_TO_UWU(splitted[i], "linuxmint", "LinUWU Miwint");
-		else KERNEL_TO_UWU(splitted[i], "manjaro", "Myanjawo");
-		else KERNEL_TO_UWU(splitted[i], "manjaro-arm", "Myanjawo AWM");
-		else KERNEL_TO_UWU(splitted[i], "neon", "KDE NeOwOn");
-		else KERNEL_TO_UWU(splitted[i], "nixos", "nixOwOs");
-		else KERNEL_TO_UWU(splitted[i], "opensuse-leap", "OwOpenSUSE Leap");
-		else KERNEL_TO_UWU(splitted[i], "opensuse-tumbleweed", "OwOpenSUSE Tumbleweed");
-		else KERNEL_TO_UWU(splitted[i], "pop", "PopOwOS");
-		else KERNEL_TO_UWU(splitted[i], "raspbian", "RaspNyan");
-		else KERNEL_TO_UWU(splitted[i], "rocky", "Wocky Linuwu");
-		else KERNEL_TO_UWU(splitted[i], "slackware", "Swackwawe");
-		else KERNEL_TO_UWU(splitted[i], "solus", "sOwOlus");
-		else KERNEL_TO_UWU(splitted[i], "ubuntu", "Uwuntu");
-		else KERNEL_TO_UWU(splitted[i], "void", "OwOid");
-		else KERNEL_TO_UWU(splitted[i], "xerolinux", "xuwulinux");
+  int count = 0;
+  while ((token = strsep(&temp_kernel, " "))) { // split kernel name
+    strcpy(splitted[count], token);
+    count++;
+  }
+  strcpy(kernel, "");
+  for (int i = 0; i < 16; i++) {
+    // replace kernel name with uwufied version
+    KERNEL_TO_UWU(splitted[i], "Linux", "Linuwu");
+    else KERNEL_TO_UWU(splitted[i], "linux", "linuwu");
+    else KERNEL_TO_UWU(splitted[i], "alpine", "Nyalpine");
+    else KERNEL_TO_UWU(splitted[i], "amogos", "AmogOwOS");
+    else KERNEL_TO_UWU(splitted[i], "android", "Nyandroid");
+    else KERNEL_TO_UWU(splitted[i], "arch", "Nyarch Linuwu");
+    else KERNEL_TO_UWU(splitted[i], "artix", "Nyartix Linuwu");
+    else KERNEL_TO_UWU(splitted[i], "debian", "Debinyan");
+    else KERNEL_TO_UWU(splitted[i], "deepin", "Dewepyn");
+    else KERNEL_TO_UWU(splitted[i], "endeavouros", "endeavOwO");
+    else KERNEL_TO_UWU(splitted[i], "EndeavourOS", "endeavOwO");
+    else KERNEL_TO_UWU(splitted[i], "fedora", "Fedowa");
+    else KERNEL_TO_UWU(splitted[i], "femboyos", "FemboyOWOS");
+    else KERNEL_TO_UWU(splitted[i], "gentoo", "GentOwO");
+    else KERNEL_TO_UWU(splitted[i], "gnu", "gnUwU");
+    else KERNEL_TO_UWU(splitted[i], "guix", "gnUwU gUwUix");
+    else KERNEL_TO_UWU(splitted[i], "linuxmint", "LinUWU Miwint");
+    else KERNEL_TO_UWU(splitted[i], "manjaro", "Myanjawo");
+    else KERNEL_TO_UWU(splitted[i], "manjaro-arm", "Myanjawo AWM");
+    else KERNEL_TO_UWU(splitted[i], "neon", "KDE NeOwOn");
+    else KERNEL_TO_UWU(splitted[i], "nixos", "nixOwOs");
+    else KERNEL_TO_UWU(splitted[i], "opensuse-leap", "OwOpenSUSE Leap");
+    else KERNEL_TO_UWU(splitted[i], "opensuse-tumbleweed", "OwOpenSUSE Tumbleweed");
+    else KERNEL_TO_UWU(splitted[i], "pop", "PopOwOS");
+    else KERNEL_TO_UWU(splitted[i], "raspbian", "RaspNyan");
+    else KERNEL_TO_UWU(splitted[i], "rocky", "Wocky Linuwu");
+    else KERNEL_TO_UWU(splitted[i], "slackware", "Swackwawe");
+    else KERNEL_TO_UWU(splitted[i], "solus", "sOwOlus");
+    else KERNEL_TO_UWU(splitted[i], "ubuntu", "Uwuntu");
+    else KERNEL_TO_UWU(splitted[i], "void", "OwOid");
+    else KERNEL_TO_UWU(splitted[i], "xerolinux", "xuwulinux");
 
-		// BSD
-		else KERNEL_TO_UWU(splitted[i], "freebsd", "FweeBSD");
-		else KERNEL_TO_UWU(splitted[i], "openbsd", "OwOpenBSD");
+    // BSD
+    else KERNEL_TO_UWU(splitted[i], "freebsd", "FweeBSD");
+    else KERNEL_TO_UWU(splitted[i], "openbsd", "OwOpenBSD");
 
-		// Apple family
-		else KERNEL_TO_UWU(splitted[i], "macos", "macOwOS");
-		else KERNEL_TO_UWU(splitted[i], "ios", "iOwOS");
+    // Apple family
+    else KERNEL_TO_UWU(splitted[i], "macos", "macOwOS");
+    else KERNEL_TO_UWU(splitted[i], "ios", "iOwOS");
 
-		// Windows
-		else KERNEL_TO_UWU(splitted[i], "windows", "WinyandOwOws");
+    // Windows
+    else KERNEL_TO_UWU(splitted[i], "windows", "WinyandOwOws");
 
-		if (i != 0) strcat(kernel, " ");
-		strcat(kernel, splitted[i]);
-	}
+    if (i != 0) strcat(kernel, " ");
+    strcat(kernel, splitted[i]);
+  }
 #undef KERNEL_TO_UWU
-	LOG_V(kernel);
+  LOG_V(kernel);
 }
 
 // uwufies hardware names
 void uwu_hw(char* hwname) {
-	LOG_I("uwufing hardware")
+  LOG_I("uwufing hardware")
 #define HW_TO_UWU(original, uwuified) replace_ignorecase(hwname, original, uwuified);
-	HW_TO_UWU("lenovo", "LenOwO")
-	HW_TO_UWU("cpu", "CPUwU");
-	HW_TO_UWU("core", "Cowe");
-	HW_TO_UWU("gpu", "GPUwU")
-	HW_TO_UWU("graphics", "Gwaphics")
-	HW_TO_UWU("corporation", "COwOpowation")
-	HW_TO_UWU("nvidia", "NyaVIDIA")
-	HW_TO_UWU("mobile", "Mwobile")
-	HW_TO_UWU("intel", "Inteww")
-	HW_TO_UWU("radeon", "Radenyan")
-	HW_TO_UWU("geforce", "GeFOwOce")
-	HW_TO_UWU("raspberry", "Nyasberry")
-	HW_TO_UWU("broadcom", "Bwoadcom")
-	HW_TO_UWU("motorola", "MotOwOwa")
-	HW_TO_UWU("proliant", "ProLinyant")
-	HW_TO_UWU("poweredge", "POwOwEdge")
-	HW_TO_UWU("apple", "Nyapple")
-	HW_TO_UWU("electronic", "ElectrOwOnic")
-	HW_TO_UWU("processor", "Pwocessow")
-	HW_TO_UWU("microsoft", "MicOwOsoft")
-	HW_TO_UWU("ryzen", "Wyzen")
-	HW_TO_UWU("advanced", "Adwanced")
-	HW_TO_UWU("micro", "Micwo")
-	HW_TO_UWU("devices", "Dewices")
-	HW_TO_UWU("inc.", "Nyanc.")
-	HW_TO_UWU("lucienne", "Lucienyan")
-	HW_TO_UWU("tuxedo", "TUWUXEDO")
-	HW_TO_UWU("aura", "Uwura")
+  HW_TO_UWU("lenovo", "LenOwO")
+  HW_TO_UWU("cpu", "CPUwU");
+  HW_TO_UWU("core", "Cowe");
+  HW_TO_UWU("gpu", "GPUwU")
+  HW_TO_UWU("graphics", "Gwaphics")
+  HW_TO_UWU("corporation", "COwOpowation")
+  HW_TO_UWU("nvidia", "NyaVIDIA")
+  HW_TO_UWU("mobile", "Mwobile")
+  HW_TO_UWU("intel", "Inteww")
+  HW_TO_UWU("radeon", "Radenyan")
+  HW_TO_UWU("geforce", "GeFOwOce")
+  HW_TO_UWU("raspberry", "Nyasberry")
+  HW_TO_UWU("broadcom", "Bwoadcom")
+  HW_TO_UWU("motorola", "MotOwOwa")
+  HW_TO_UWU("proliant", "ProLinyant")
+  HW_TO_UWU("poweredge", "POwOwEdge")
+  HW_TO_UWU("apple", "Nyapple")
+  HW_TO_UWU("electronic", "ElectrOwOnic")
+  HW_TO_UWU("processor", "Pwocessow")
+  HW_TO_UWU("microsoft", "MicOwOsoft")
+  HW_TO_UWU("ryzen", "Wyzen")
+  HW_TO_UWU("advanced", "Adwanced")
+  HW_TO_UWU("micro", "Micwo")
+  HW_TO_UWU("devices", "Dewices")
+  HW_TO_UWU("inc.", "Nyanc.")
+  HW_TO_UWU("lucienne", "Lucienyan")
+  HW_TO_UWU("tuxedo", "TUWUXEDO")
+  HW_TO_UWU("aura", "Uwura")
 #undef HW_TO_UWU
 }
 
 // uwufies package manager names
 void uwu_pkgman(char* pkgman_name) {
-	LOG_I("uwufing package managers")
+  LOG_I("uwufing package managers")
 #define PKGMAN_TO_UWU(original, uwuified) replace_ignorecase(pkgman_name, original, uwuified);
-	// these package managers do not have edits yet:
-	// apk, apt, guix, nix, pkg, xbps
-	PKGMAN_TO_UWU("brew-cask", "bwew-cawsk");
-	PKGMAN_TO_UWU("brew-cellar", "bwew-cewwaw");
-	PKGMAN_TO_UWU("emerge", "emewge");
-	PKGMAN_TO_UWU("flatpak", "fwatpakkies");
-	PKGMAN_TO_UWU("pacman", "pacnyan");
-	PKGMAN_TO_UWU("port", "powt");
-	PKGMAN_TO_UWU("rpm", "rawrpm");
-	PKGMAN_TO_UWU("snap", "snyap");
-	PKGMAN_TO_UWU("zypper", "zyppew");
+  // these package managers do not have edits yet:
+  // apk, apt, guix, nix, pkg, xbps
+  PKGMAN_TO_UWU("brew-cask", "bwew-cawsk");
+  PKGMAN_TO_UWU("brew-cellar", "bwew-cewwaw");
+  PKGMAN_TO_UWU("emerge", "emewge");
+  PKGMAN_TO_UWU("flatpak", "fwatpakkies");
+  PKGMAN_TO_UWU("pacman", "pacnyan");
+  PKGMAN_TO_UWU("port", "powt");
+  PKGMAN_TO_UWU("rpm", "rawrpm");
+  PKGMAN_TO_UWU("snap", "snyap");
+  PKGMAN_TO_UWU("zypper", "zyppew");
 #undef PKGMAN_TO_UWU
 }
 
 // uwufies everything
 void uwufy_all(struct info* user_info) {
-	LOG_I("uwufing everything");
-	if (strcmp(user_info->os_name, "windows"))
-		MOVE_CURSOR = "\033[21C"; // to print windows logo on not windows systems
-	uwu_kernel(user_info->kernel);
-	for (int i = 0; user_info->gpu_model[i][0]; i++) uwu_hw(user_info->gpu_model[i]);
-	uwu_hw(user_info->cpu_model);
-	LOG_V(user_info->cpu_model);
-	uwu_hw(user_info->model);
-	LOG_V(user_info->model);
-	uwu_pkgman(user_info->pkgman_name);
-	LOG_V(user_info->pkgman_name);
+  LOG_I("uwufing everything");
+  if (strcmp(user_info->os_name, "windows"))
+    MOVE_CURSOR = "\033[21C"; // to print windows logo on not windows systems
+  uwu_kernel(user_info->kernel);
+  for (int i = 0; user_info->gpu_model[i][0]; i++) uwu_hw(user_info->gpu_model[i]);
+  uwu_hw(user_info->cpu_model);
+  LOG_V(user_info->cpu_model);
+  uwu_hw(user_info->model);
+  LOG_V(user_info->model);
+  uwu_pkgman(user_info->pkgman_name);
+  LOG_V(user_info->pkgman_name);
 }
 
 // prints all the collected info and returns the number of printed lines
 int print_info(struct configuration* config_flags, struct info* user_info) {
-	int line_count = 0;
+  int line_count = 0;
 #ifdef _WIN32
-	// prints without overflowing the terminal width
-	#define responsively_printf(buf, format, ...)     \
-		{                                               \
-			sprintf(buf, format, __VA_ARGS__);            \
-			printf("%.*s\n", user_info->ws_col - 4, buf); \
-			line_count++;                                 \
-		}
+  // prints without overflowing the terminal width
+  #define responsively_printf(buf, format, ...)     \
+    {                                               \
+      sprintf(buf, format, __VA_ARGS__);            \
+      printf("%.*s\n", user_info->ws_col - 4, buf); \
+      line_count++;                                 \
+    }
 #else // _WIN32
-	// prints without overflowing the terminal width
-	#define responsively_printf(buf, format, ...)         \
-		{                                                   \
-			sprintf(buf, format, __VA_ARGS__);                \
-			printf("%.*s\n", user_info->win.ws_col - 4, buf); \
-			line_count++;                                     \
-		}
-#endif									// _WIN32
-	char print_buf[1024]; // for responsively print
+  // prints without overflowing the terminal width
+  #define responsively_printf(buf, format, ...)         \
+    {                                                   \
+      sprintf(buf, format, __VA_ARGS__);                \
+      printf("%.*s\n", user_info->win.ws_col - 4, buf); \
+      line_count++;                                     \
+    }
+#endif                  // _WIN32
+  char print_buf[1024]; // for responsively print
 
-	// print collected info - from host to cpu info
-	if (config_flags->show.user)
-		responsively_printf(print_buf, "%s%s%s%s@%s", MOVE_CURSOR, NORMAL, BOLD, user_info->user, user_info->host);
-	uwu_name(user_info);
-	if (config_flags->show.os)
-		responsively_printf(print_buf, "%s%s%sOWOS     %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->os_name);
-	if (config_flags->show.model)
-		responsively_printf(print_buf, "%s%s%sMOWODEL  %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->model);
-	if (config_flags->show.kernel)
-		responsively_printf(print_buf, "%s%s%sKEWNEL   %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->kernel);
-	if (config_flags->show.cpu)
-		responsively_printf(print_buf, "%s%s%sCPUWU    %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->cpu_model);
+  // print collected info - from host to cpu info
+  if (config_flags->show.user)
+    responsively_printf(print_buf, "%s%s%s%s@%s", MOVE_CURSOR, NORMAL, BOLD, user_info->user, user_info->host);
+  uwu_name(user_info);
+  if (config_flags->show.os)
+    responsively_printf(print_buf, "%s%s%sOWOS     %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->os_name);
+  if (config_flags->show.model)
+    responsively_printf(print_buf, "%s%s%sMOWODEL  %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->model);
+  if (config_flags->show.kernel)
+    responsively_printf(print_buf, "%s%s%sKEWNEL   %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->kernel);
+  if (config_flags->show.cpu)
+    responsively_printf(print_buf, "%s%s%sCPUWU    %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->cpu_model);
 
-	for (int i = 0; i < 256; i++) {
-		if (config_flags->show_gpu[i])
-			if (user_info->gpu_model[i][0])
-				responsively_printf(print_buf, "%s%s%sGPUWU    %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->gpu_model[i]);
-	}
+  for (int i = 0; i < 256; i++) {
+    if (config_flags->show_gpu[i])
+      if (user_info->gpu_model[i][0])
+        responsively_printf(print_buf, "%s%s%sGPUWU    %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->gpu_model[i]);
+  }
 
-	if (config_flags->show.ram) // print ram
-		responsively_printf(print_buf, "%s%s%sMEMOWY   %s%i MiB/%i MiB", MOVE_CURSOR, NORMAL, BOLD, NORMAL, (user_info->ram_used), user_info->ram_total);
-	if (config_flags->show.resolution) // print resolution
-		if (user_info->screen_width != 0 || user_info->screen_height != 0)
-			responsively_printf(print_buf, "%s%s%sWESOWUTION%s  %dx%d", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->screen_width, user_info->screen_height);
-	if (config_flags->show.shell) // print shell name
-		responsively_printf(print_buf, "%s%s%sSHEWW    %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->shell);
-	if (config_flags->show.pkgs) // print pkgs
-		responsively_printf(print_buf, "%s%s%sPKGS     %s%d: %s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->pkgs, user_info->pkgman_name);
-	// #endif
-	if (config_flags->show.uptime) {
-		switch (user_info->uptime) { // formatting the uptime which is store in seconds
-		case 0 ... 3599:
-			responsively_printf(print_buf, "%s%s%sUWUPTIME %s%lim", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->uptime / 60 % 60);
-			break;
-		case 3600 ... 86399:
-			responsively_printf(print_buf, "%s%s%sUWUPTIME %s%lih, %lim", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->uptime / 3600, user_info->uptime / 60 % 60);
-			break;
-		default:
-			responsively_printf(print_buf, "%s%s%sUWUPTIME %s%lid, %lih, %lim", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->uptime / 86400, user_info->uptime / 3600 % 24, user_info->uptime / 60 % 60);
-		}
-	}
-	// clang-format off
+  if (config_flags->show.ram) // print ram
+    responsively_printf(print_buf, "%s%s%sMEMOWY   %s%i MiB/%i MiB", MOVE_CURSOR, NORMAL, BOLD, NORMAL, (user_info->ram_used), user_info->ram_total);
+  if (config_flags->show.resolution) // print resolution
+    if (user_info->screen_width != 0 || user_info->screen_height != 0)
+      responsively_printf(print_buf, "%s%s%sWESOWUTION%s  %dx%d", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->screen_width, user_info->screen_height);
+  if (config_flags->show.shell) // print shell name
+    responsively_printf(print_buf, "%s%s%sSHEWW    %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->shell);
+  if (config_flags->show.pkgs) // print pkgs
+    responsively_printf(print_buf, "%s%s%sPKGS     %s%d: %s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->pkgs, user_info->pkgman_name);
+  // #endif
+  if (config_flags->show.uptime) {
+    switch (user_info->uptime) { // formatting the uptime which is store in seconds
+    case 0 ... 3599:
+      responsively_printf(print_buf, "%s%s%sUWUPTIME %s%lim", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->uptime / 60 % 60);
+      break;
+    case 3600 ... 86399:
+      responsively_printf(print_buf, "%s%s%sUWUPTIME %s%lih, %lim", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->uptime / 3600, user_info->uptime / 60 % 60);
+      break;
+    default:
+      responsively_printf(print_buf, "%s%s%sUWUPTIME %s%lid, %lih, %lim", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->uptime / 86400, user_info->uptime / 3600 % 24, user_info->uptime / 60 % 60);
+    }
+  }
+  // clang-format off
 	if (config_flags->show_colors)
 		printf("%s"	BOLD BLACK BLOCK_CHAR BLOCK_CHAR RED BLOCK_CHAR
 								BLOCK_CHAR GREEN BLOCK_CHAR BLOCK_CHAR YELLOW
 								BLOCK_CHAR BLOCK_CHAR BLUE BLOCK_CHAR BLOCK_CHAR
 								MAGENTA BLOCK_CHAR BLOCK_CHAR CYAN BLOCK_CHAR
 								BLOCK_CHAR WHITE BLOCK_CHAR BLOCK_CHAR NORMAL "\n", MOVE_CURSOR);
-	// clang-format on
-	return line_count;
+  // clang-format on
+  return line_count;
 }
 
 // writes cache to cache file
 void write_cache(struct info* user_info) {
-	LOG_I("writing cache");
-	char cache_file[512];
-	sprintf(cache_file, "%s/.cache/uwufetch.cache", getenv("HOME")); // default cache file location
-	LOG_V(cache_file);
-	FILE* cache_fp = fopen(cache_file, "w");
-	if (cache_fp == NULL) {
-		LOG_E("Failed to write to %s!", cache_file);
-		return;
-	}
-	// writing all info to the cache file
-	fprintf( // writing most of the values to config file
-			cache_fp,
-			"user=%s\nhost=%s\nversion_name=%s\nhost_model=%s\nkernel=%s\ncpu=%"
-			"s\nscreen_width=%d\nscreen_height=%d\nshell=%s\npkgs=%d\npkgman_name=%"
-			"s\n",
-			user_info->user, user_info->host, user_info->os_name, user_info->model, user_info->kernel,
-			user_info->cpu_model, user_info->screen_width, user_info->screen_height, user_info->shell,
-			user_info->pkgs, user_info->pkgman_name);
+  LOG_I("writing cache");
+  char cache_file[512];
+  sprintf(cache_file, "%s/.cache/uwufetch.cache", getenv("HOME")); // default cache file location
+  LOG_V(cache_file);
+  FILE* cache_fp = fopen(cache_file, "w");
+  if (cache_fp == NULL) {
+    LOG_E("Failed to write to %s!", cache_file);
+    return;
+  }
+  // writing all info to the cache file
+  fprintf( // writing most of the values to config file
+      cache_fp,
+      "user=%s\nhost=%s\nversion_name=%s\nhost_model=%s\nkernel=%s\ncpu=%"
+      "s\nscreen_width=%d\nscreen_height=%d\nshell=%s\npkgs=%d\npkgman_name=%"
+      "s\n",
+      user_info->user, user_info->host, user_info->os_name, user_info->model, user_info->kernel,
+      user_info->cpu_model, user_info->screen_width, user_info->screen_height, user_info->shell,
+      user_info->pkgs, user_info->pkgman_name);
 
-	for (int i = 0; user_info->gpu_model[i][0]; i++) // writing gpu names to file
-		fprintf(cache_fp, "gpu=%s\n", user_info->gpu_model[i]);
+  for (int i = 0; user_info->gpu_model[i][0]; i++) // writing gpu names to file
+    fprintf(cache_fp, "gpu=%s\n", user_info->gpu_model[i]);
 
-	fclose(cache_fp);
-	return;
+  fclose(cache_fp);
+  return;
 }
 
 // reads cache file if it exists
 int read_cache(struct info* user_info) {
-	LOG_I("reading cache");
-	char cache_file[512];
-	sprintf(cache_file, "%s/.cache/uwufetch.cache", getenv("HOME")); // cache file location
-	LOG_V(cache_file);
-	FILE* cache_fp = fopen(cache_file, "r");
-	if (cache_fp == NULL) return 0;
-	char buffer[256];																	// line buffer
-	int gpuc = 0;																			// gpu counter
-	while (fgets(buffer, sizeof(buffer), cache_fp)) { // reading the file
-		sscanf(buffer, "user=%99[^\n]", user_info->user);
-		sscanf(buffer, "host=%99[^\n]", user_info->host);
-		sscanf(buffer, "version_name=%99[^\n]", user_info->os_name);
-		sscanf(buffer, "host_model=%99[^\n]", user_info->model);
-		sscanf(buffer, "kernel=%99[^\n]", user_info->kernel);
-		sscanf(buffer, "cpu=%99[^\n]", user_info->cpu_model);
-		if (sscanf(buffer, "gpu=%99[^\n]", user_info->gpu_model[gpuc]) != 0) gpuc++;
-		sscanf(buffer, "screen_width=%i", &user_info->screen_width);
-		sscanf(buffer, "screen_height=%i", &user_info->screen_height);
-		sscanf(buffer, "shell=%99[^\n]", user_info->shell);
-		sscanf(buffer, "pkgs=%i", &user_info->pkgs);
-		sscanf(buffer, "pkgman_name=%99[^\n]", user_info->pkgman_name);
-	}
-	LOG_V(user_info->user);
-	LOG_V(user_info->host);
-	LOG_V(user_info->os_name);
-	LOG_V(user_info->model);
-	LOG_V(user_info->kernel);
-	LOG_V(user_info->cpu_model);
-	LOG_V(user_info->gpu_model[gpuc]);
-	LOG_V(user_info->screen_width);
-	LOG_V(user_info->screen_height);
-	LOG_V(user_info->shell);
-	LOG_V(user_info->pkgs);
-	LOG_V(user_info->pkgman_name);
-	fclose(cache_fp);
-	return 1;
+  LOG_I("reading cache");
+  char cache_file[512];
+  sprintf(cache_file, "%s/.cache/uwufetch.cache", getenv("HOME")); // cache file location
+  LOG_V(cache_file);
+  FILE* cache_fp = fopen(cache_file, "r");
+  if (cache_fp == NULL) return 0;
+  char buffer[256];                                 // line buffer
+  int gpuc = 0;                                     // gpu counter
+  while (fgets(buffer, sizeof(buffer), cache_fp)) { // reading the file
+    sscanf(buffer, "user=%99[^\n]", user_info->user);
+    sscanf(buffer, "host=%99[^\n]", user_info->host);
+    sscanf(buffer, "version_name=%99[^\n]", user_info->os_name);
+    sscanf(buffer, "host_model=%99[^\n]", user_info->model);
+    sscanf(buffer, "kernel=%99[^\n]", user_info->kernel);
+    sscanf(buffer, "cpu=%99[^\n]", user_info->cpu_model);
+    if (sscanf(buffer, "gpu=%99[^\n]", user_info->gpu_model[gpuc]) != 0) gpuc++;
+    sscanf(buffer, "screen_width=%i", &user_info->screen_width);
+    sscanf(buffer, "screen_height=%i", &user_info->screen_height);
+    sscanf(buffer, "shell=%99[^\n]", user_info->shell);
+    sscanf(buffer, "pkgs=%i", &user_info->pkgs);
+    sscanf(buffer, "pkgman_name=%99[^\n]", user_info->pkgman_name);
+  }
+  LOG_V(user_info->user);
+  LOG_V(user_info->host);
+  LOG_V(user_info->os_name);
+  LOG_V(user_info->model);
+  LOG_V(user_info->kernel);
+  LOG_V(user_info->cpu_model);
+  LOG_V(user_info->gpu_model[gpuc]);
+  LOG_V(user_info->screen_width);
+  LOG_V(user_info->screen_height);
+  LOG_V(user_info->shell);
+  LOG_V(user_info->pkgs);
+  LOG_V(user_info->pkgman_name);
+  fclose(cache_fp);
+  return 1;
 }
 
 // prints logo (as ascii art) of the given system.
 int print_ascii(struct info* user_info) {
-	FILE* file;
-	char ascii_file[1024];
-	// First tries to get ascii art file from local directory. Useful for debugging
-	sprintf(ascii_file, "./res/ascii/%s.txt", user_info->os_name);
-	LOG_V(ascii_file);
-	file = fopen(ascii_file, "r");
-	if (!file) { // if the file does not exist in the local directory, open it from the installation directory
-		if (strcmp(user_info->os_name, "android") == 0)
-			sprintf(ascii_file, "/data/data/com.termux/files/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
-		else if (strcmp(user_info->os_name, "macos") == 0)
-			sprintf(ascii_file, "/usr/local/lib/uwufetch/ascii/%s.txt", user_info->os_name);
-		else
-			sprintf(ascii_file, "/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
-		LOG_V(ascii_file);
+  FILE* file;
+  char ascii_file[1024];
+  // First tries to get ascii art file from local directory. Useful for debugging
+  sprintf(ascii_file, "./res/ascii/%s.txt", user_info->os_name);
+  LOG_V(ascii_file);
+  file = fopen(ascii_file, "r");
+  if (!file) { // if the file does not exist in the local directory, open it from the installation directory
+    if (strcmp(user_info->os_name, "android") == 0)
+      sprintf(ascii_file, "/data/data/com.termux/files/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
+    else if (strcmp(user_info->os_name, "macos") == 0)
+      sprintf(ascii_file, "/usr/local/lib/uwufetch/ascii/%s.txt", user_info->os_name);
+    else
+      sprintf(ascii_file, "/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
+    LOG_V(ascii_file);
 
-		file = fopen(ascii_file, "r");
-		if (!file) {
-			// Prevent infinite loops
-			if (strcmp(user_info->os_name, "unknown") == 0) {
-				LOG_E("No\nunknown\nascii\nfile\n\n\n\n");
-				return 7;
-			}
-			sprintf(user_info->os_name, "unknown"); // current os is not supported
-			LOG_V(user_info->os_name);
-			return print_ascii(user_info);
-		}
-	}
-	char buffer[256]; // line buffer
-	int line_count = 1;
-	printf("\n");
-	while (fgets(buffer, 256, file)) { // replacing color placecholders
-		replace(buffer, "{NORMAL}", NORMAL);
-		replace(buffer, "{BOLD}", BOLD);
-		replace(buffer, "{BLACK}", BLACK);
-		replace(buffer, "{RED}", RED);
-		replace(buffer, "{GREEN}", GREEN);
-		replace(buffer, "{SPRING_GREEN}", SPRING_GREEN);
-		replace(buffer, "{YELLOW}", YELLOW);
-		replace(buffer, "{BLUE}", BLUE);
-		replace(buffer, "{MAGENTA}", MAGENTA);
-		replace(buffer, "{CYAN}", CYAN);
-		replace(buffer, "{WHITE}", WHITE);
-		replace(buffer, "{PINK}", PINK);
-		replace(buffer, "{LPINK}", LPINK);
-		replace(buffer, "{BLOCK}", BLOCK_CHAR);
-		replace(buffer, "{BLOCK_VERTICAL}", BLOCK_CHAR);
-		replace(buffer, "{BACKGROUND_GREEN}", "\e[0;42m");
-		replace(buffer, "{BACKGROUND_RED}", "\e[0;41m");
-		replace(buffer, "{BACKGROUND_WHITE}", "\e[0;47m");
-		printf("%s", buffer); // print the line after setting the color
-		line_count++;
-	}
-	// Always set color to NORMAL, so there's no need to do this in every ascii file.
-	printf(NORMAL);
-	fclose(file);
-	return line_count;
+    file = fopen(ascii_file, "r");
+    if (!file) {
+      // Prevent infinite loops
+      if (strcmp(user_info->os_name, "unknown") == 0) {
+        LOG_E("No\nunknown\nascii\nfile\n\n\n\n");
+        return 7;
+      }
+      sprintf(user_info->os_name, "unknown"); // current os is not supported
+      LOG_V(user_info->os_name);
+      return print_ascii(user_info);
+    }
+  }
+  char buffer[256]; // line buffer
+  int line_count = 1;
+  printf("\n");
+  while (fgets(buffer, 256, file)) { // replacing color placecholders
+    replace(buffer, "{NORMAL}", NORMAL);
+    replace(buffer, "{BOLD}", BOLD);
+    replace(buffer, "{BLACK}", BLACK);
+    replace(buffer, "{RED}", RED);
+    replace(buffer, "{GREEN}", GREEN);
+    replace(buffer, "{SPRING_GREEN}", SPRING_GREEN);
+    replace(buffer, "{YELLOW}", YELLOW);
+    replace(buffer, "{BLUE}", BLUE);
+    replace(buffer, "{MAGENTA}", MAGENTA);
+    replace(buffer, "{CYAN}", CYAN);
+    replace(buffer, "{WHITE}", WHITE);
+    replace(buffer, "{PINK}", PINK);
+    replace(buffer, "{LPINK}", LPINK);
+    replace(buffer, "{BLOCK}", BLOCK_CHAR);
+    replace(buffer, "{BLOCK_VERTICAL}", BLOCK_CHAR);
+    replace(buffer, "{BACKGROUND_GREEN}", "\e[0;42m");
+    replace(buffer, "{BACKGROUND_RED}", "\e[0;41m");
+    replace(buffer, "{BACKGROUND_WHITE}", "\e[0;47m");
+    printf("%s", buffer); // print the line after setting the color
+    line_count++;
+  }
+  // Always set color to NORMAL, so there's no need to do this in every ascii file.
+  printf(NORMAL);
+  fclose(file);
+  return line_count;
 }
 
 /* prints distribution list
-	 distributions are listed by distribution branch
-	 to make the output easier to understand by the user.*/
+   distributions are listed by distribution branch
+   to make the output easier to understand by the user.*/
 void list(char* arg) {
-	LOG_I("printing supported distro list");
-	// clang-format off
+  LOG_I("printing supported distro list");
+  // clang-format off
 	printf("%s -d <options>\n"
 				 "  Available distributions:\n"
 				 "    "BLUE"Arch linux "NORMAL"based:\n"
@@ -683,154 +683,154 @@ void list(char* arg) {
 				 "    "NORMAL"Other/spare distributions:\n"
 				 "      "BLUE"alpine, "PINK"femboyos, gentoo, "MAGENTA"slackware, "WHITE"solus, "GREEN"void, opensuse-leap, android, "YELLOW"gnu, guix, "BLUE"windows, "WHITE"unknown\n\n",
 				 arg); // Other/spare distributions colors
-	// clang-format on
+  // clang-format on
 }
 
 // prints the usage
 void usage(char* arg) {
-	LOG_I("printing usage");
-	printf("Usage: %s <args>\n"
-				 "    -c  --config        use custom config path\n"
-				 "    -d, --distro        lets you choose the logo to print\n"
-				 "    -h, --help          prints this help page\n"
+  LOG_I("printing usage");
+  printf("Usage: %s <args>\n"
+         "    -c  --config        use custom config path\n"
+         "    -d, --distro        lets you choose the logo to print\n"
+         "    -h, --help          prints this help page\n"
 #ifndef __IPHONE__
-				 "    -i, --image         prints logo as image and use a custom image "
-				 "if provided\n"
-				 "                        %sworks in most terminals\n"
+         "    -i, --image         prints logo as image and use a custom image "
+         "if provided\n"
+         "                        %sworks in most terminals\n"
 #else
-				 "    -i, --image         prints logo as image and use a custom image "
-				 "if provided\n"
-				 "                        %sdisabled under iOS\n"
+         "    -i, --image         prints logo as image and use a custom image "
+         "if provided\n"
+         "                        %sdisabled under iOS\n"
 #endif
-				 "                        read README.md for more info%s\n"
-				 "    -l, --list          lists all supported distributions\n"
-				 "    -V, --version       prints the current uwufetch version\n"
+         "                        read README.md for more info%s\n"
+         "    -l, --list          lists all supported distributions\n"
+         "    -V, --version       prints the current uwufetch version\n"
 #ifdef __DEBUG__
-				 "    -v, --verbose       logs everything\n"
+         "    -v, --verbose       logs everything\n"
 #endif
-				 "    -w, --write-cache   writes to the cache file (~/.cache/uwufetch.cache)\n"
-				 "    -r, --read-cache    reads from the cache file (~/.cache/uwufetch.cache)\n",
-				 arg,
+         "    -w, --write-cache   writes to the cache file (~/.cache/uwufetch.cache)\n"
+         "    -r, --read-cache    reads from the cache file (~/.cache/uwufetch.cache)\n",
+         arg,
 #ifndef __IPHONE__
-				 BLUE,
+         BLUE,
 #else
-				 RED,
+         RED,
 #endif
-				 NORMAL);
+         NORMAL);
 }
 
 // the main function is on the bottom of the file to avoid double function declarations
 int main(int argc, char* argv[]) {
 #ifdef __DEBUG__
-	verbose_enabled = get_verbose_handle();
+  verbose_enabled = get_verbose_handle();
 #endif
-	struct user_config user_config_file = {0};
-	struct info user_info								= {0};
-	struct configuration config_flags		= parse_config(&user_info, &user_config_file);
-	char* custom_distro_name						= NULL;
-	char* custom_image_name							= NULL;
+  struct user_config user_config_file = {0};
+  struct info user_info               = {0};
+  struct configuration config_flags   = parse_config(&user_info, &user_config_file);
+  char* custom_distro_name            = NULL;
+  char* custom_image_name             = NULL;
 
 #ifdef _WIN32
-	// packages disabled by default because chocolatey is too slow
-	config_flags.show.pkgs = 0;
+  // packages disabled by default because chocolatey is too slow
+  config_flags.show.pkgs = 0;
 #endif
 
-	int opt											 = 0;
-	struct option long_options[] = {
-			{"config", required_argument, NULL, 'c'},
-			{"distro", required_argument, NULL, 'd'},
-			{"help", no_argument, NULL, 'h'},
-			{"image", optional_argument, NULL, 'i'},
-			{"list", no_argument, NULL, 'l'},
-			{"read-cache", no_argument, NULL, 'r'},
-			{"version", no_argument, NULL, 'V'},
+  int opt                      = 0;
+  struct option long_options[] = {
+      {"config", required_argument, NULL, 'c'},
+      {"distro", required_argument, NULL, 'd'},
+      {"help", no_argument, NULL, 'h'},
+      {"image", optional_argument, NULL, 'i'},
+      {"list", no_argument, NULL, 'l'},
+      {"read-cache", no_argument, NULL, 'r'},
+      {"version", no_argument, NULL, 'V'},
 #ifdef __DEBUG__
-			{"verbose", no_argument, NULL, 'v'},
+      {"verbose", no_argument, NULL, 'v'},
 #endif
-			{"write-cache", no_argument, NULL, 'w'},
-			{0}};
+      {"write-cache", no_argument, NULL, 'w'},
+      {0}};
 #ifdef __DEBUG__
-	#define OPT_STRING "c:d:hi::lrVvw"
+  #define OPT_STRING "c:d:hi::lrVvw"
 #else
-	#define OPT_STRING "c:d:hi::lrVw"
+  #define OPT_STRING "c:d:hi::lrVw"
 #endif
 
-	// reading cmdline options
-	while ((opt = getopt_long(argc, argv, OPT_STRING, long_options, NULL)) != -1) {
-		switch (opt) {
-		case 'c': // set the config directory
-			user_config_file.config_directory = optarg;
-			config_flags											= parse_config(&user_info, &user_config_file);
-			break;
-		case 'd': // set the distribution name
-			custom_distro_name = optarg;
-			break;
-		case 'h':
-			usage(argv[0]);
-			return 0;
-		case 'i': // set ascii logo as output
-			config_flags.show_image = true;
-			if (argv[optind]) custom_image_name = argv[optind];
-			break;
-		case 'l':
-			list(argv[0]);
-			return 0;
-		case 'r':
-			user_config_file.read_enabled = true;
-			break;
-		case 'V':
-			printf("UwUfetch version %s\n", UWUFETCH_VERSION);
-			return 0;
+  // reading cmdline options
+  while ((opt = getopt_long(argc, argv, OPT_STRING, long_options, NULL)) != -1) {
+    switch (opt) {
+    case 'c': // set the config directory
+      user_config_file.config_directory = optarg;
+      config_flags                      = parse_config(&user_info, &user_config_file);
+      break;
+    case 'd': // set the distribution name
+      custom_distro_name = optarg;
+      break;
+    case 'h':
+      usage(argv[0]);
+      return 0;
+    case 'i': // set ascii logo as output
+      config_flags.show_image = true;
+      if (argv[optind]) custom_image_name = argv[optind];
+      break;
+    case 'l':
+      list(argv[0]);
+      return 0;
+    case 'r':
+      user_config_file.read_enabled = true;
+      break;
+    case 'V':
+      printf("UwUfetch version %s\n", UWUFETCH_VERSION);
+      return 0;
 #ifdef __DEBUG__
-		case 'v':
-			*verbose_enabled = true;
-			LOG_I("version %s", UWUFETCH_VERSION);
-			break;
+    case 'v':
+      *verbose_enabled = true;
+      LOG_I("version %s", UWUFETCH_VERSION);
+      break;
 #endif
-		case 'w':
-			user_config_file.write_enabled = true;
-			break;
-		default:
-			return 1;
-		}
-	}
+    case 'w':
+      user_config_file.write_enabled = true;
+      break;
+    default:
+      return 1;
+    }
+  }
 
-	if (user_config_file.read_enabled) {
-		// if no cache file found write to it
-		if (!read_cache(&user_info)) {
-			user_config_file.read_enabled	 = false;
-			user_config_file.write_enabled = true;
-		} else {
-			int buf_sz = 256;
-			char buffer[buf_sz]; // line buffer
-			struct thread_varg vargp = {
-					buffer, &user_info, NULL, {true, true, true, true, true, true, true, true}};
-			if (config_flags.show.ram) get_ram(&vargp);
-			if (config_flags.show.uptime) {
-				LOG_I("getting additional not-cached info");
-				get_sys(&user_info);
-				get_upt(&vargp);
-			}
-		}
-	}
-	if (!user_config_file.read_enabled)
-		get_info(config_flags.show, &user_info);
-	LOG_V(user_info.gpu_model[1]);
+  if (user_config_file.read_enabled) {
+    // if no cache file found write to it
+    if (!read_cache(&user_info)) {
+      user_config_file.read_enabled  = false;
+      user_config_file.write_enabled = true;
+    } else {
+      int buf_sz = 256;
+      char buffer[buf_sz]; // line buffer
+      struct thread_varg vargp = {
+          buffer, &user_info, NULL, {true, true, true, true, true, true, true, true}};
+      if (config_flags.show.ram) get_ram(&vargp);
+      if (config_flags.show.uptime) {
+        LOG_I("getting additional not-cached info");
+        get_sys(&user_info);
+        get_upt(&vargp);
+      }
+    }
+  }
+  if (!user_config_file.read_enabled)
+    get_info(config_flags.show, &user_info);
+  LOG_V(user_info.gpu_model[1]);
 
-	if (user_config_file.write_enabled) {
-		write_cache(&user_info);
-	}
-	if (custom_distro_name) sprintf(user_info.os_name, "%s", custom_distro_name);
-	if (custom_image_name) sprintf(user_info.image_name, "%s", custom_image_name);
+  if (user_config_file.write_enabled) {
+    write_cache(&user_info);
+  }
+  if (custom_distro_name) sprintf(user_info.os_name, "%s", custom_distro_name);
+  if (custom_image_name) sprintf(user_info.image_name, "%s", custom_image_name);
 
-	uwufy_all(&user_info);
+  uwufy_all(&user_info);
 
-	// print ascii or image and align cursor for print_info()
-	printf("\033[%dA", config_flags.show_image ? print_image(&user_info) : print_ascii(&user_info));
+  // print ascii or image and align cursor for print_info()
+  printf("\033[%dA", config_flags.show_image ? print_image(&user_info) : print_ascii(&user_info));
 
-	// print info and move cursor down if the number of printed lines is smaller that the default image height
-	int to_move = 9 - print_info(&config_flags, &user_info);
-	printf("\033[%d%c", to_move < 0 ? -to_move : to_move, to_move < 0 ? 'A' : 'B');
-	LOG_I("Execution completed successfully!");
-	return 0;
+  // print info and move cursor down if the number of printed lines is smaller that the default image height
+  int to_move = 9 - print_info(&config_flags, &user_info);
+  printf("\033[%d%c", to_move < 0 ? -to_move : to_move, to_move < 0 ? 'A' : 'B');
+  LOG_I("Execution completed successfully!");
+  return 0;
 }

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -829,7 +829,8 @@ int main(int argc, char* argv[]) {
 	printf("\033[%dA", config_flags.show_image ? print_image(&user_info) : print_ascii(&user_info));
 
 	// print info and move cursor down if the number of printed lines is smaller that the default image height
-	printf("\033[%dB", 9 - print_info(&config_flags, &user_info));
+	int to_move = 9 - print_info(&config_flags, &user_info);
+	printf("\033[%d%c", to_move < 0 ? -to_move : to_move, to_move < 0 ? 'A' : 'B');
 	LOG_I("Execution completed successfully!");
 	return 0;
 }


### PR DESCRIPTION
Please refer to the commit messages for a detailed explanation for these changes.

[Makefile conventions](https://www.gnu.org/software/make/manual/html_node/Makefile-Conventions.html): 
I tried to improve the build system flexibility for distro packagers and end users by respecting common user-defined variables such as `CC`, `AR`, `{C,LD}FLAGS`. Now the build system correctly applies the prefix to all install paths and lets users redefine them in a granular way.
This does not apply to Windows as I don't have enough experience with installation procedures on that OS. I'm happy to add further fixes.

I updated the library-related targets to install a versioned binary (both API and ABI wise) as it's commonly done.

Manpages are now uncompressed upon installation to allow for different compression algorithms and levels. Here's a link to a more eloquent explanation: https://cmpct.info/~sam/blog/posts/automatic-manpage-compression/

Add git to the build requirements as it's used to set the version string.
